### PR TITLE
Usability/AN-549-change-private-property-on-models

### DIFF
--- a/api/common/controller-dependencies.js
+++ b/api/common/controller-dependencies.js
@@ -114,6 +114,7 @@ const dependencies = {
         break;
       case 'Model':
         if ('active' in element) element.active = element.active === 1;
+        element.isPrivate = Boolean(element.isPrivate);
         break;
       case 'Region':
         element.country = global.hexToString(element.country);
@@ -125,7 +126,7 @@ const dependencies = {
         if (element.processDefinitionId != null) element.processDefinitionId = global.hexToString(element.processDefinitionId);
         if (element.interfaceId != null) element.interfaceId = global.hexToString(element.interfaceId);
         if (element.modelId != null) element.modelId = global.hexToString(element.modelId);
-        // Nothing yet
+        element.isPrivate = Boolean(element.isPrivate);
         break;
       case 'Task':
         if (element.activityId) element.activityId = global.hexToString(element.activityId);

--- a/api/controllers/bpm-controller.js
+++ b/api/controllers/bpm-controller.js
@@ -347,7 +347,7 @@ const getDefinition = asyncMiddleware(async (req, res) => {
   const processDefn = await sqlCache.getProcessDefinitionData(req.params.address);
   const profileData = await sqlCache.getProfile(req.user.address);
   if (!processDefn) throw boom.notFound(`Data for process definition ${req.params.address} not found`);
-  if (processDefn.private &&
+  if (processDefn.isPrivate &&
     processDefn.author !== req.user.address &&
     !profileData.find(({ organization }) => organization === processDefn.author)) {
     throw boom.forbidden('You are not authorized to view process details from this private model');
@@ -374,7 +374,7 @@ const getModelDiagram = asyncMiddleware(async (req, res) => {
   const model = await sqlCache.getProcessModelData(req.params.address);
   if (!model) throw boom.notFound(`Data for process model ${req.params.address} not found`);
   const profileData = await sqlCache.getProfile(req.user.address);
-  if (model.private &&
+  if (model.isPrivate &&
     model.author !== req.user.address &&
     !profileData.find(({ organization }) => organization === model.author)) {
     throw boom.forbidden('You are not authorized to view this private model');
@@ -581,7 +581,7 @@ const createModelFromBpmn = asyncMiddleware(async (req, res) => {
   const hoardRef = await pushModelXmlToHoard(rawXml);
   response.model.address = await contracts.createProcessModel(model.id, model.name, model.version, model.author, model.private, hoardRef.address, hoardRef.secretKey);
   response.processes = await addProcessesToModel(response.model.address, processes);
-  response.processes = response.processes.map(_proc => Object.assign(_proc, { private: model.private, author: model.author }));
+  response.processes = response.processes.map(_proc => Object.assign(_proc, { isPrivate: model.isPrivate, author: model.author }));
   response.parsedDiagram = parsedResponse;
   return res.status(200).json(response);
 });

--- a/api/controllers/sqlsol-query-helper.js
+++ b/api/controllers/sqlsol-query-helper.js
@@ -438,7 +438,7 @@ const getTasksByUserAddress = userAddress => new Promise((resolve, reject) => {
 });
 
 const getModels = author => new Promise((resolve, reject) => {
-  const queryString = `SELECT modelAddress, id, name, author, isPrivate AS private, active, diagramAddress, diagramSecret, versionMajor, versionMinor, versionPatch FROM process_models WHERE private = 0 OR author = '${author}'`;
+  const queryString = `SELECT modelAddress, id, name, author, isPrivate, active, diagramAddress, diagramSecret, versionMajor, versionMinor, versionPatch FROM process_models WHERE isPrivate = 0 OR author = '${author}'`;
   contracts.cache.db.all(queryString, (err, data) => {
     if (err) return reject(boom.badImplementation(`Failed to get process model(s): ${err}`));
     return resolve(data);
@@ -458,7 +458,7 @@ const getApplications = () => new Promise((resolve, reject) => {
 const getProcessDefinitions = (author, interfaceId) => new Promise((resolve, reject) => {
   let hexInterfaceId = Buffer.from(interfaceId || '').toString('hex');
   hexInterfaceId = rightPad(hexInterfaceId.toUpperCase(), 32);
-  const queryString = 'SELECT pd.id as processDefinitionId, pd.processDefinitionAddress AS address, pd.modelAddress, pd.interfaceId, pm.id as modelId, pm.diagramAddress, pm.diagramSecret, pm.isPrivate AS private, pm.author ' +
+  const queryString = 'SELECT pd.id as processDefinitionId, pd.processDefinitionAddress AS address, pd.modelAddress, pd.interfaceId, pm.id as modelId, pm.diagramAddress, pm.diagramSecret, pm.isPrivate, pm.author ' +
     'FROM process_definitions pd JOIN process_models pm ' +
     'ON pd.modelAddress = pm.modelAddress ' +
     `WHERE pm.isPrivate = 0 OR pm.author = '${author}' ${(interfaceId ? `AND interfaceId = '${hexInterfaceId}'` : '')}`;
@@ -469,7 +469,7 @@ const getProcessDefinitions = (author, interfaceId) => new Promise((resolve, rej
 });
 
 const getProcessDefinitionData = address => new Promise((resolve, reject) => {
-  const queryString = 'SELECT pd.id as processDefinitionId, pd.processDefinitionAddress AS address, pd.modelAddress, pd.interfaceId, pm.diagramAddress, pm.diagramSecret, pm.isPrivate AS private, pm.author, pm.id as modelId ' +
+  const queryString = 'SELECT pd.id as processDefinitionId, pd.processDefinitionAddress AS address, pd.modelAddress, pd.interfaceId, pm.diagramAddress, pm.diagramSecret, pm.isPrivate, pm.author, pm.id as modelId ' +
       'FROM process_definitions pd JOIN process_models pm ' +
       'ON pd.modelAddress = pm.modelAddress WHERE pd.processDefinitionAddress = ?;';
   contracts.cache.db.get(queryString, address, (err, data) => {
@@ -479,7 +479,7 @@ const getProcessDefinitionData = address => new Promise((resolve, reject) => {
 });
 
 const getProcessModelData = address => new Promise((resolve, reject) => {
-  const queryString = 'SELECT modelAddress, id, name, author, isPrivate AS private, active, diagramAddress, diagramSecret, versionMajor, versionMinor, versionPatch FROM process_models pm ' +
+  const queryString = 'SELECT modelAddress, id, name, author, isPrivate, active, diagramAddress, diagramSecret, versionMajor, versionMinor, versionPatch FROM process_models pm ' +
                         'WHERE pm.modelAddress = ?;';
   contracts.cache.db.get(queryString, address, (err, data) => {
     if (err) return reject(boom.badImplementation(`Failed to get process model: ${err}`));


### PR DESCRIPTION
Use 'isPrivate' instead of 'private' in response payload for process models and definitions

Signed-off-by: Ommi Shimizu <oshimizu15@gmail.com>