### PR TITLE
Consolidating solidity unit test returns

### DIFF
--- a/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
@@ -60,7 +60,7 @@ contract ActiveAgreementRegistryTest {
 	ArchetypeRegistry public archRegistry = new DefaultArchetypeRegistry();
 	ArchetypeRegistryDb archRegistryDb = new ArchetypeRegistryDb();
 
-	function testActiveAgreementRegistry() external returns (uint, string) {
+	function testActiveAgreementRegistry() external returns (string) {
 
 	  uint error;
 		address addr;
@@ -74,15 +74,15 @@ contract ActiveAgreementRegistryTest {
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))), 
 			0x0, agreementName, this, dummyHoardAddress, dummyHoardSecret, dummyEventLogHoardAddress, dummyEventLogHoardSecret, maxNumberOfEvents, false, parties, EMPTY, emptyArray)) {
-				return (BaseErrors.INVALID_STATE(), "Expected error NULL_PARAM_NOT_ALLOWED for empty archetype address");
+				return "$1";
 		}
 
 		activeAgreement = agreementRegistry.createAgreement(archetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, dummyEventLogHoardAddress, dummyEventLogHoardSecret, maxNumberOfEvents, false, parties, EMPTY, emptyArray);
-		if (activeAgreement == 0x0) return (BaseErrors.INVALID_STATE(), "Agreement creation returned empty address");
+		if (activeAgreement == 0x0) return "Agreement creation returned empty address";
 
-		if (agreementRegistry.getActiveAgreementAtIndex(0) != activeAgreement) return (BaseErrors.INVALID_STATE(), "ActiveAgreement at index 0 not as expected");
-		if (agreementRegistry.getPartiesByActiveAgreementSize(activeAgreement) != parties.length) return (BaseErrors.INVALID_STATE(), "Parties size on created agreement not correct");
-		if (agreementRegistry.getPartyByActiveAgreementAtIndex(activeAgreement, 2) != falseAddress) return (BaseErrors.INVALID_STATE(), "Lookup of party at index 2 on created agreement not correct");
+		if (agreementRegistry.getActiveAgreementAtIndex(0) != activeAgreement) return "ActiveAgreement at index 0 not as expected";
+		if (agreementRegistry.getPartiesByActiveAgreementSize(activeAgreement) != parties.length) return "Parties size on created agreement not correct";
+		if (agreementRegistry.getPartyByActiveAgreementAtIndex(activeAgreement, 2) != falseAddress) return "$1";
 
 		// test external data retrieval
 		address retArchetype;
@@ -93,22 +93,22 @@ contract ActiveAgreementRegistryTest {
 		bool retIsPrivate;
 		(retArchetype, retName, retCreator, retHoardAddress, retHoardSecret, , , , retIsPrivate, , , ) = agreementRegistry.getActiveAgreementData(activeAgreement);
 		
-		if (retArchetype != address(archetype)) return (BaseErrors.INVALID_STATE(), "getActiveAgreementData returned wrong archetype");
-		if (retName != agreementName) return (BaseErrors.INVALID_STATE(), "getActiveAgreementData returned wrong name");
-		if (retCreator != address(this)) return (BaseErrors.INVALID_STATE(), "getActiveAgreementData returned wrong creator");
-		if (retHoardAddress != dummyHoardAddress) return (BaseErrors.INVALID_STATE(), "getActiveAgreementData returned wrong hoard address");
-		if (retHoardSecret != dummyHoardSecret) return (BaseErrors.INVALID_STATE(), "getActiveAgreementData returned wrong hoard secret");
-		if (retIsPrivate != false) return (BaseErrors.INVALID_STATE(), "getActiveAgreementData returned wrong isPrivate");
+		if (retArchetype != address(archetype)) return "$1";
+		if (retName != agreementName) return "getActiveAgreementData returned wrong name";
+		if (retCreator != address(this)) return "getActiveAgreementData returned wrong creator";
+		if (retHoardAddress != dummyHoardAddress) return "$1";
+		if (retHoardSecret != dummyHoardSecret) return "$1";
+		if (retIsPrivate != false) return "$1";
 
 		// test external party data retrieval
 		uint timestamp;
 		(addr, timestamp) = agreementRegistry.getPartyByActiveAgreementData(activeAgreement, falseAddress);
-		if (timestamp != 0) return (BaseErrors.INVALID_STATE(), "Party data signature timestamp for false address expected to be 0");
+		if (timestamp != 0) return "$1";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
-	function testAgreementCollections() external returns (uint, string) {
+	function testAgreementCollections() external returns (string) {
 
 		uint error;
 
@@ -123,66 +123,66 @@ contract ActiveAgreementRegistryTest {
 		agreementRegistry.setArchetypeRegistry(archRegistry);
 
 		archetypeAddr = archRegistry.createArchetype("archetype name", falseAddress, "description", 10, false, true, falseAddress, falseAddress, EMPTY, emptyArray);
-		if (archetypeAddr == 0x0) return (BaseErrors.INVALID_STATE(), "Archetype creation returned empty address");
+		if (archetypeAddr == 0x0) return "Archetype creation returned empty address";
 
 		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardAddress, dummyHoardSecret, dummyEventLogHoardAddress, dummyEventLogHoardSecret, maxNumberOfEvents, false, parties, EMPTY, emptyArray);
-		if (activeAgreement == 0x0) return (BaseErrors.INVALID_STATE(), "Agreement creation returned empty address");
+		if (activeAgreement == 0x0) return "Agreement creation returned empty address";
 
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked("addAgreementToCollection(bytes32,address)"))), fakeCollectionId, activeAgreement)) {
-			return (BaseErrors.INVALID_STATE(), "Expected RESOURCE_NOT_FOUND for non-existent collection id");
+			return "Expected RESOURCE_NOT_FOUND for non-existent collection id";
 		}
 
 		(error, leaseCollectionId) = agreementRegistry.createAgreementCollection(leaseCollection, 0x0, uint8(Agreements.CollectionType.MATTER), fakePackageId);
-		if (error != BaseErrors.NULL_PARAM_NOT_ALLOWED()) return (BaseErrors.INVALID_STATE(), "Expected failure due to no author address");
+		if (error != BaseErrors.NULL_PARAM_NOT_ALLOWED()) return "Expected failure due to no author address";
 		
 		(error, leaseCollectionId) = agreementRegistry.createAgreementCollection(leaseCollection, falseAddress, uint8(Agreements.CollectionType.MATTER), EMPTY);
-		if (error != BaseErrors.NULL_PARAM_NOT_ALLOWED()) return (BaseErrors.INVALID_STATE(), "Expected failure due to no archetype package id");
+		if (error != BaseErrors.NULL_PARAM_NOT_ALLOWED()) return "$1";
 
 		(error, leaseCollectionId) = agreementRegistry.createAgreementCollection(leaseCollection, falseAddress, uint8(Agreements.CollectionType.MATTER), fakePackageId);
-		if (error != BaseErrors.NO_ERROR()) return (BaseErrors.INVALID_STATE(), "It should create a new collection");
-		if (leaseCollectionId == "") return (BaseErrors.INVALID_STATE(), "Collection id should not be empty");
+		if (error != BaseErrors.NO_ERROR()) return "It should create a new collection";
+		if (leaseCollectionId == "") return "Collection id should not be empty";
 
 		(error, leaseCollectionId) = agreementRegistry.createAgreementCollection(leaseCollection, falseAddress, uint8(Agreements.CollectionType.MATTER), fakePackageId);
-		if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return (BaseErrors.INVALID_STATE(), "Expected failure when creating collection with duplicate name/author");
+		if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
 
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked("addAgreementToCollection(bytes32,address)"))), leaseCollectionId, activeAgreement)) {
-			return (BaseErrors.INVALID_STATE(), "Expected INVALID_ACTION for collection referencing a package which does not contain the agreement's archetype");
+			return "$1";
 		}
 
 		// creating a real package that contains the archetype for this agreement
 		(error, realPackageId) = archRegistry.createArchetypePackage(packageName, packageDesc, falseAddress, false, true);
-		if (error != BaseErrors.NO_ERROR()) return (BaseErrors.INVALID_STATE(), "Failed to create archetype package via agreementRegistry");
-		if (realPackageId == "") return (BaseErrors.INVALID_STATE(), "Archetype package creation had no error, but package id is empty");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (realPackageId == "") return "$1";
 
 		if (!address(archRegistry).call(bytes4(keccak256(abi.encodePacked("addArchetypeToPackage(bytes32,address)"))), realPackageId, archetypeAddr)) {
-			return (BaseErrors.INVALID_STATE(), "Failed to add archetype to package");
+			return "Failed to add archetype to package";
 		}
 
 		// creating a new collection that references the new package
 		(error, leaseCollectionId2) = agreementRegistry.createAgreementCollection(leaseCollection2, falseAddress, uint8(Agreements.CollectionType.MATTER), realPackageId);
-		if (error != BaseErrors.NO_ERROR()) return (BaseErrors.INVALID_STATE(), "It should create a new collection referecing the real package");
-		if (leaseCollectionId2 == "") return (BaseErrors.INVALID_STATE(), "Collection id referenceing the real package should not be empty");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (leaseCollectionId2 == "") return "$1";
 
 		if (!address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked("addAgreementToCollection(bytes32,address)"))), leaseCollectionId2, activeAgreement)) {
-			return (BaseErrors.INVALID_STATE(), "Expected to successfully add agreement to collection referencing a package that contains the agreement's archetype");
+			return "$1";
 		}
 
-		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 1) return (BaseErrors.INVALID_STATE(), "Lease collection 2 should have 1 agreement");
-		if (agreementRegistry.getAgreementAtIndexInCollection(leaseCollectionId2, 0) != activeAgreement) return (BaseErrors.INVALID_STATE(), "Agreement at index 0 of lease collection 2 should match activeAgreement");
+		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 1) return "Lease collection 2 should have 1 agreement";
+		if (agreementRegistry.getAgreementAtIndexInCollection(leaseCollectionId2, 0) != activeAgreement) return "$1";
 		
 		(error, buildingCollectionId) = agreementRegistry.createAgreementCollection(buildingCollection, falseAddress, uint8(Agreements.CollectionType.MATTER), fakePackageId);
-		if (error != BaseErrors.NO_ERROR()) return (BaseErrors.INVALID_STATE(), "It should create a new building collection");
-		if (buildingCollectionId == "") return (BaseErrors.INVALID_STATE(), "Building Collection id should not be empty");
+		if (error != BaseErrors.NO_ERROR()) return "It should create a new building collection";
+		if (buildingCollectionId == "") return "Building Collection id should not be empty";
 
-		if (agreementRegistry.getNumberOfAgreementCollections() != 3) return (BaseErrors.INVALID_STATE(), "Registry should have 3 collections");
+		if (agreementRegistry.getNumberOfAgreementCollections() != 3) return "Registry should have 3 collections";
 
 		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardAddress, dummyHoardSecret, dummyEventLogHoardAddress, dummyEventLogHoardSecret, maxNumberOfEvents, false, parties, leaseCollectionId2, emptyArray);
-		if (activeAgreement2 == 0x0) return (BaseErrors.INVALID_STATE(), "Failed to create a second agreement to put into lease collection 2");
+		if (activeAgreement2 == 0x0) return "$1";
 
-		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 2) return (BaseErrors.INVALID_STATE(), "Lease collection 2 should now have 2 agreements");
-		if (agreementRegistry.getAgreementAtIndexInCollection(leaseCollectionId2, 1) != activeAgreement2) return (BaseErrors.INVALID_STATE(), "Agreement at index 1 should match activeAgreement2");
+		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 2) return "$1";
+		if (agreementRegistry.getAgreementAtIndexInCollection(leaseCollectionId2, 1) != activeAgreement2) return "$1";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
 	function testGoverningAgreements() external returns (string) {

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -34,7 +34,7 @@ contract ActiveAgreementTest {
 	/**
 	 * @dev Covers the setup and proper data retrieval of an agreement
 	 */
-	function testActiveAgreementSetup() external returns (uint, string) {
+	function testActiveAgreementSetup() external returns (string) {
 
 		address result;
 	  ActiveAgreement agreement;
@@ -48,28 +48,28 @@ contract ActiveAgreementTest {
 		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, dummyEventLogHoardAddress, dummyEventLogHoardSecret, maxNumberOfEvents, false, parties, emptyArray);
 		agreement.setDataValueAsAddressArray(bogusId, bogusArray);
 
-		if (agreement.getName() != agreementName) return (BaseErrors.INVALID_STATE(), "Name not set correctly");
-		if (agreement.getNumberOfParties() != parties.length) return (BaseErrors.INVALID_STATE(), "Number of parties not returning expected size");
+		if (agreement.getName() != agreementName) return "Name not set correctly";
+		if (agreement.getNumberOfParties() != parties.length) return "Number of parties not returning expected size";
 
 		result = agreement.getPartyAtIndex(1);
-		if (result != address(signer2)) return (BaseErrors.INVALID_STATE(), "Address of party at index 1 not as expected");
+		if (result != address(signer2)) return "Address of party at index 1 not as expected";
 
-		if (agreement.getArchetype() != address(archetype)) return (BaseErrors.INVALID_STATE(), "Archetype not set correctly");
+		if (agreement.getArchetype() != address(archetype)) return "Archetype not set correctly";
 
 		// test parties array retrieval via DataStorage (needed for workflow participants)
 		address[100] memory partiesArr = agreement.getDataValueAsAddressArray(DATA_FIELD_AGREEMENT_PARTIES);
 		address[100] memory bogusArr = agreement.getDataValueAsAddressArray(bogusId);
-		if (partiesArr[0] != address(signer1)) return (BaseErrors.INVALID_STATE(), "address[] retrieval via DATA_FIELD_AGREEMENT_PARTIES did not yield first element as expected");
-		if (bogusArr[0] != address(0xCcD5bA65282C3dafB69b19351C7D5B77b9fDDCA6)) return (BaseErrors.INVALID_STATE(), "address[] retrieval via regular ID did not yield first element as expected");
-		if (agreement.getNumberOfArrayEntries(DATA_FIELD_AGREEMENT_PARTIES, false) != agreement.getNumberOfParties()) return (BaseErrors.INVALID_STATE(), "Array size count via DATA_FIELD_AGREEMENT_PARTIES did not match the number of parties");
+		if (partiesArr[0] != address(signer1)) return "$1";
+		if (bogusArr[0] != address(0xCcD5bA65282C3dafB69b19351C7D5B77b9fDDCA6)) return "$1";
+		if (agreement.getNumberOfArrayEntries(DATA_FIELD_AGREEMENT_PARTIES, false) != agreement.getNumberOfParties()) return "$1";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
 	/**
 	 * @dev Covers testing signing an agreement via users and organizations and the associated state changes.
 	 */
-	function testActiveAgreementSigning() external returns (uint, string) {
+	function testActiveAgreementSigning() external returns (string) {
 
 		uint error;
 	  	ActiveAgreement agreement;
@@ -79,7 +79,7 @@ contract ActiveAgreementTest {
 		// Signer 2 is signing on behalf of an organization
 		address[10] memory emptyAddressArray;
 		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray);
-		if (!org1.addUser(signer2)) return (error, "Unable to add user account to organization");
+		if (!org1.addUser(signer2)) return "Unable to add user account to organization";
 		delete parties;
 		parties.push(address(signer1));
 		parties.push(address(org1));
@@ -91,38 +91,38 @@ contract ActiveAgreementTest {
 		address signee;
 		uint timestamp;
 		if (address(agreement).call(bytes4(keccak256(abi.encodePacked("sign()")))))
-			return (BaseErrors.INVALID_STATE(), "Signing from test address should REVERT due to invalid actor");
+			return "Signing from test address should REVERT due to invalid actor";
 		(signee, timestamp) = agreement.getSignatureDetails(signer1);
-		if (timestamp != 0) return (BaseErrors.INVALID_STATE(), "Signature timestamp for signer1 should be 0 before signing");
-		if (AgreementsAPI.isFullyExecuted(agreement)) return (BaseErrors.INVALID_STATE(), "AgreementsAPI.isFullyExecuted should be false before signing");
-		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return (BaseErrors.INVALID_STATE(), "Agreement legal state should NOT be EXECUTED");
+		if (timestamp != 0) return "$1";
+		if (AgreementsAPI.isFullyExecuted(agreement)) return "$1";
+		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return "Agreement legal state should NOT be EXECUTED";
 
 		// Signing with Signer1 as party
 		signer1.signAgreement(agreement);
-		if (!agreement.isSignedBy(signer1)) return (BaseErrors.INVALID_STATE(), "Agreement should be signed by signer1");
+		if (!agreement.isSignedBy(signer1)) return "Agreement should be signed by signer1";
 		(signee, timestamp) = agreement.getSignatureDetails(signer1);
-		if (signee != address(signer1)) return (BaseErrors.INVALID_STATE(), "Signee for signer1 should be signer1");
-		if (timestamp == 0) return (BaseErrors.INVALID_STATE(), "Signature timestamp for signer1 should be set after signing");
-		if (AgreementsAPI.isFullyExecuted(agreement)) return (BaseErrors.INVALID_STATE(), "AgreementsAPI.isFullyExecuted should be false after signer1");
-		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return (BaseErrors.INVALID_STATE(), "Agreement legal state should NOT be EXECUTED after signer1");
+		if (signee != address(signer1)) return "Signee for signer1 should be signer1";
+		if (timestamp == 0) return "$1";
+		if (AgreementsAPI.isFullyExecuted(agreement)) return "$1";
+		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return "$1";
 
 		// Signing with Signer2 via the organization
 		signer2.signAgreement(agreement);
-		if (!agreement.isSignedBy(signer1)) return (BaseErrors.INVALID_STATE(), "Agreement should be signed by signer2");
-		if (agreement.isSignedBy(org1)) return (BaseErrors.INVALID_STATE(), "Agreement should NOT be signed by org1");
+		if (!agreement.isSignedBy(signer1)) return "Agreement should be signed by signer2";
+		if (agreement.isSignedBy(org1)) return "Agreement should NOT be signed by org1";
 		(signee, timestamp) = agreement.getSignatureDetails(org1);
-		if (signee != address(signer2)) return (BaseErrors.INVALID_STATE(), "Signee for org1 should be signer1");
-		if (timestamp == 0) return (BaseErrors.INVALID_STATE(), "Signature timestamp for org1 should be set after signing");
-		if (!AgreementsAPI.isFullyExecuted(agreement)) return (BaseErrors.INVALID_STATE(), "AgreementsAPI.isFullyExecuted should be true after signer2");
-		if (agreement.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return (BaseErrors.INVALID_STATE(), "Agreement legal state should be EXECUTED after signer2");
+		if (signee != address(signer2)) return "Signee for org1 should be signer1";
+		if (timestamp == 0) return "$1";
+		if (!AgreementsAPI.isFullyExecuted(agreement)) return "$1";
+		if (agreement.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
 	/**
 	 * @dev Covers canceling an agreement in different stages
 	 */
-	function testActiveAgreementCancellation() external returns (uint, string) {
+	function testActiveAgreementCancellation() external returns (string) {
 
 		ActiveAgreement agreement1;
 		ActiveAgreement agreement2;
@@ -138,24 +138,24 @@ contract ActiveAgreementTest {
 
 		// test invalid cancellation and states
 		if (address(agreement1).call(bytes4(keccak256(abi.encodePacked("cancel()")))))
-			return (BaseErrors.INVALID_STATE(), "Canceling from test address should REVERT due to invalid actor");
-		if (agreement1.getLegalState() == uint8(Agreements.LegalState.CANCELED)) return (BaseErrors.INVALID_STATE(), "Agreement1 legal state should NOT be CANCELED");
-		if (agreement2.getLegalState() == uint8(Agreements.LegalState.CANCELED)) return (BaseErrors.INVALID_STATE(), "Agreement2 legal state should NOT be CANCELED");
+			return "Canceling from test address should REVERT due to invalid actor";
+		if (agreement1.getLegalState() == uint8(Agreements.LegalState.CANCELED)) return "Agreement1 legal state should NOT be CANCELED";
+		if (agreement2.getLegalState() == uint8(Agreements.LegalState.CANCELED)) return "Agreement2 legal state should NOT be CANCELED";
 
 		// Agreement1 is canceled during formation
 		signer2.cancelAgreement(agreement1);
-		if (agreement1.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return (BaseErrors.INVALID_STATE(), "Agreement1 legal state should be CANCELED after unilateral cancellation in formation");
+		if (agreement1.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "$1";
 
 		// Agreement2 is canceled during execution
 		signer1.signAgreement(agreement2);
 		signer2.signAgreement(agreement2);
-		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return (BaseErrors.INVALID_STATE(), "Agreemen2 legal state should be EXECUTED after parties signed");
+		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
 		signer1.cancelAgreement(agreement2);
-		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return (BaseErrors.INVALID_STATE(), "Agreement2 legal state should still be EXECUTED after unilateral cancellation");
+		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
 		signer2.cancelAgreement(agreement2);
-		if (agreement2.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return (BaseErrors.INVALID_STATE(), "Agreement2 legal state should still be CANCELED after bilateral cancellation");
+		if (agreement2.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "$1";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
 }

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.23;
 import "commons-base/BaseErrors.sol";
 import "commons-base/SystemOwned.sol";
 import "commons-utils/DataTypes.sol";
+import "commons-utils/TypeUtilsAPI.sol";
 import "commons-auth/ParticipantsManager.sol";
 import "commons-auth/Organization.sol";
 import "commons-auth/DefaultOrganization.sol";
@@ -26,6 +27,8 @@ import "agreements/AgreementSignatureCheck.sol";
 
 contract ActiveAgreementWorkflowTest {
 
+	using TypeUtilsAPI for bytes32;
+	
 	// test data
 	bytes32 activityId1 = "activity1";
 	bytes32 activityId2 = "activity2";
@@ -117,7 +120,7 @@ contract ActiveAgreementWorkflowTest {
 		pd.createTransition(activityId1, activityId2);
 		pd.createTransition(activityId2, activityId3);
 		(bool valid, bytes32 errorMsg) = pd.validate();
-		if (!valid) return bytes32ToString(errorMsg);
+		if (!valid) return errorMsg.toString();
 
 		// create a PI with agreement
 		ProcessInstance pi = new DefaultProcessInstance(pd, this, EMPTY);
@@ -140,7 +143,7 @@ contract ActiveAgreementWorkflowTest {
 	/**
 	 * Tests a typical AN workflow with a multi-instance signing activity that produces an executed agreement
 	 */
-	function testExecutedAgreementWorkflow() external returns (uint, string) {
+	function testExecutedAgreementWorkflow() external returns (string) {
 
 		// re-usable variables for return values
 		uint error;
@@ -161,16 +164,16 @@ contract ActiveAgreementWorkflowTest {
 		TestSignatureCheck signatureCheckApp = new TestSignatureCheck();
 		applicationRegistry.addApplication("AgreementSignatureCheck", BpmModel.ApplicationType.WEB, signatureCheckApp, bytes4(EMPTY), EMPTY);
 		doug.deployContract("AgreementSignatureCheck", signatureCheckApp);
-		if (signatureCheckApp.getBpmService() != address(bpmService)) return (BaseErrors.INVALID_STATE(), "BpmService not injected successfully into AgreementSignatureCheck application");
+		if (signatureCheckApp.getBpmService() != address(bpmService)) return "$1";
 
 		//
 		// ORGS/USERS
 		//
 		(error, addr) = agreementRegistry.createUserAccount(participantsManager, user1Id, this, address(0));
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error creating user account1 via BpmService");
+		if (error != BaseErrors.NO_ERROR()) return "Error creating user account1 via BpmService";
 		userAccount1 = AgreementPartyAccount(addr);
 		(error, addr) = agreementRegistry.createUserAccount(participantsManager, "john.smith", this, address(0));
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error creating user account2 via BpmService");
+		if (error != BaseErrors.NO_ERROR()) return "Error creating user account2 via BpmService";
 		nonPartyAccount = AgreementPartyAccount(addr);
 		// create additional users via constructor
 		userAccount2 = new AgreementPartyAccount(user2Id, this, address(0));
@@ -193,32 +196,32 @@ contract ActiveAgreementWorkflowTest {
 		//
 		ProcessModel pm;
 		(error, addr) = processModelRepository.createProcessModel("AN-Model", "AN Model", [1,0,0], userAccount1, false, EMPTY, EMPTY);
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Unable to create a ProcessModel");
+		if (addr == 0x0) return "Unable to create a ProcessModel";
 		pm = ProcessModel(addr);
 		pm.addParticipant(participantId1, 0x0, DATA_FIELD_AGREEMENT_PARTIES, agreementRegistry.DATA_ID_AGREEMENT(), 0x0);
 		// Formation Process
 		(error, addr) = pm.createProcessDefinition("FormationProcess");
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Unable to create FormationProcess definition");
+		if (addr == 0x0) return "Unable to create FormationProcess definition";
 		formationPD = ProcessDefinition(addr);
 		error = formationPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.USER, BpmModel.TaskBehavior.SENDRECEIVE, participantId1, true, appIdSignatureCheck, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error creating USER task for formation process definition");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		formationPD.createDataMapping(activityId1, BpmModel.Direction.IN, "agreement", "agreement", EMPTY, 0x0);
 		(valid, errorMsg) = formationPD.validate();
-		if (!valid) return (BaseErrors.INVALID_STATE(), bytes32ToString(errorMsg));
+		if (!valid) return errorMsg.toString();
 		// Execution Process
 		(error, addr) = pm.createProcessDefinition("ExecutionProcess");
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Unable to create ExecutionProcess definition");
+		if (addr == 0x0) return "Unable to create ExecutionProcess definition";
 		executionPD = ProcessDefinition(addr);
 		error = executionPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.SEND, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error creating SERVICE task for execution process definition");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		(valid, errorMsg) = executionPD.validate();
-		if (!valid) return (BaseErrors.INVALID_STATE(), bytes32ToString(errorMsg));
+		if (!valid) return errorMsg.toString();
 
 		//
 		// ARCHETYPE
 		//
 		addr = archetypeRegistry.createArchetype("TestArchetype", this, "description", 10, false, true, formationPD, executionPD, EMPTY, governingArchetypes);
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Error creating TestArchetype, address is empty");
+		if (addr == 0x0) return "Error creating TestArchetype, address is empty";
 
 		//
 		// AGREEMENT
@@ -227,80 +230,80 @@ contract ActiveAgreementWorkflowTest {
 		// Org2 has a department, so we're setting the additional context on the agreement
 		ActiveAgreement(agreement).setAddressScope(address(org2), DATA_FIELD_AGREEMENT_PARTIES, departmentId1, EMPTY, EMPTY, 0x0);
 		//TODO we currently don't support a negotiation phase in the AN, so the agreement's prose contract is already formulated when the agreement is created.
-		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FORMULATED)) return (BaseErrors.INVALID_STATE(), "The agreement should be in FORMULATED state");
+		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FORMULATED)) return "The agreement should be in FORMULATED state";
 
 		//
 		// FORMATION / EXECUTION
 		//
-		if (bpmService.getNumberOfProcessInstances() != 0) return (BaseErrors.INVALID_STATE(), "There should be 0 PIs in the system at test start");
+		if (bpmService.getNumberOfProcessInstances() != 0) return "$1";
 		(error, addr) = agreementRegistry.startFormation(ActiveAgreement(agreement));
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error starting the formation on agreement");
-		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FORMULATED)) return (BaseErrors.INVALID_STATE(), "The agreement should be in FORMULATED state");
+		if (error != BaseErrors.NO_ERROR()) return "Error starting the formation on agreement";
+		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FORMULATED)) return "The agreement should be in FORMULATED state";
 
 		ProcessInstance pi;
-		if (bpmService.getNumberOfProcessInstances() != 1) return (BaseErrors.INVALID_STATE(), "There should be 1 PI in the system after agreement formation start");
-		if (bpmService.getBpmServiceDb().getNumberOfActivityInstances() != 3) return (BaseErrors.INVALID_STATE(), "There should be 3 AIs total");
+		if (bpmService.getNumberOfProcessInstances() != 1) return "$1";
+		if (bpmService.getBpmServiceDb().getNumberOfActivityInstances() != 3) return "There should be 3 AIs total";
 		pi = ProcessInstance(bpmService.getProcessInstanceAtIndex(0));
-		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return (BaseErrors.INVALID_STATE(), "The Formation PI should be active");
+		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The Formation PI should be active";
 		( , , , addr, , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return (BaseErrors.INVALID_STATE(), "Activity1 in Formation Process should be suspended");
-		if (addr != address(userAccount1)) return (BaseErrors.INVALID_STATE(), "userAccount1 should be the performer of activity1");
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
+		if (addr != address(userAccount1)) return "$1";
 
 		// the agreement should NOT be available as IN data via the application at this point since the user is still the performer!
 		if (address(signatureCheckApp).call(keccak256(abi.encodePacked("getInDataAgreement(bytes32)")), pi.getActivityInstanceAtIndex(0)))
-			return (BaseErrors.INVALID_STATE(), "Retrieving IN data via the application should REVERT while the user is still the performer");
+			return "$1";
 
 		// test fail on invalid user
 		error = nonPartyAccount.completeActivity(pi.getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.INVALID_ACTOR()) return (BaseErrors.INVALID_STATE(), "Attempting to complete the Sign activity with an unassigned user should fail.");
+		if (error != BaseErrors.INVALID_ACTOR()) return "$1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return (BaseErrors.INVALID_STATE(), "Activity1 in Formation Process should still be suspended after wrong user attempt");
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
 		// test fail on unsigned agreement
 		error = userAccount1.completeActivity(pi.getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.RUNTIME_ERROR()) return (error, "Attempting to complete the Sign activity without signing the agreement should fail");
+		if (error != BaseErrors.RUNTIME_ERROR()) return "$1";
 		( , , , addr, , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return (BaseErrors.INVALID_STATE(), "Activity1 in Formation Process should still be suspended after completion attempt without signing");
-		if (addr != address(userAccount1)) return (BaseErrors.INVALID_STATE(), "userAccount1 should still be the performer of activity1 even after completion failed");
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
+		if (addr != address(userAccount1)) return "$1";
 
 		// test successful completion
 		userAccount1.signAgreement(agreement);
 		error = userAccount1.completeActivity(pi.getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error attempting to complete Activity1 in Formation Process by user1");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "ActivityInstance 1 in Formation Process should be completed");
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
 
 		// verify that the signature app had access to the agreement data mapping
-		if (signatureCheckApp.lastAgreement() != address(agreement)) return (BaseErrors.INVALID_STATE(), "The agreement should've been processed by the TestSignatureCheck app.");
+		if (signatureCheckApp.lastAgreement() != address(agreement)) return "$1";
 
 		// complete the missing signatures and tasks
 		userAccount2.signAgreement(agreement);
 		error = userAccount2.completeActivity(pi.getActivityInstanceAtIndex(1), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error attempting to complete Activity1 in Formation Process by user2 in org1");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "ActivityInstance 2 in Formation Process should be completed");
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
 
 		userAccount3.signAgreement(agreement);
 
-		if (pi.resolveAddressScope(address(org2), activityId1, pi) != departmentId1) return (BaseErrors.INVALID_STATE(), "Org2 in context of activity1 should show the additional department scope");
+		if (pi.resolveAddressScope(address(org2), activityId1, pi) != departmentId1) return "$1";
 		error = userAccount3.completeActivity(pi.getActivityInstanceAtIndex(2), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error attempting to complete Activity1 in Formation Process by user3 in org2");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(2));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "ActivityInstance 3 in Formation Process should be completed");
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
 
 		// AIs 1-3 should all be completed now and the process has moved into execution
-		if (bpmService.getNumberOfProcessInstances() != 2) return (BaseErrors.INVALID_STATE(), "There should be 2 PIs in the system after agreement formation is completed");
-		if (bpmService.getBpmServiceDb().getNumberOfActivityInstances() != 4) return (BaseErrors.INVALID_STATE(), "There should be 4 AIs total");
+		if (bpmService.getNumberOfProcessInstances() != 2) return "$1";
+		if (bpmService.getBpmServiceDb().getNumberOfActivityInstances() != 4) return "There should be 4 AIs total";
 		pi = ProcessInstance(bpmService.getProcessInstanceAtIndex(1));
-		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "The Execution PI should be completed");
-		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FULFILLED)) return (BaseErrors.INVALID_STATE(), "The agreement should be in FULFILLED state");
+		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The Execution PI should be completed";
+		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FULFILLED)) return "The agreement should be in FULFILLED state";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
 	/**
 	 * Tests workflow handling where the agreement gets cancelled during formation as well as execution.
 	 */
-	function testCanceledAgreementWorkflow() external returns (uint, string) {
+	function testCanceledAgreementWorkflow() external returns (string) {
 
 		// re-usable variables for return values
 		uint error;
@@ -329,30 +332,30 @@ contract ActiveAgreementWorkflowTest {
 		//
 		ProcessModel pm;
 		(error, addr) = processModelRepository.createProcessModel("Cancellation-Model", "Cancellation Model", [1,0,0], userAccount1, false, EMPTY, EMPTY);
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Unable to create a ProcessModel");
+		if (addr == 0x0) return "Unable to create a ProcessModel";
 		pm = ProcessModel(addr);
 		// Formation Process
 		(error, addr) = pm.createProcessDefinition("FormationProcess");
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Unable to create FormationProcess definition");
+		if (addr == 0x0) return "Unable to create FormationProcess definition";
 		formationPD = ProcessDefinition(addr);
 		error = formationPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.RECEIVE, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error creating NONE task for formation process definition");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		(valid, errorMsg) = formationPD.validate();
-		if (!valid) return (BaseErrors.INVALID_STATE(), bytes32ToString(errorMsg));
+		if (!valid) return errorMsg.toString();
 		// Execution Process
 		(error, addr) = pm.createProcessDefinition("ExecutionProcess");
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Unable to create ExecutionProcess definition");
+		if (addr == 0x0) return "Unable to create ExecutionProcess definition";
 		executionPD = ProcessDefinition(addr);
 		error = executionPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.RECEIVE, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error creating SERVICE task for execution process definition");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		(valid, errorMsg) = executionPD.validate();
-		if (!valid) return (BaseErrors.INVALID_STATE(), bytes32ToString(errorMsg));
+		if (!valid) return errorMsg.toString();
 
 		//
 		// ARCHETYPE
 		//
 		addr = archetypeRegistry.createArchetype("TestArchetype", this, "description", 10, false, true, formationPD, executionPD, EMPTY, governingArchetypes);
-		if (addr == 0x0) return (BaseErrors.INVALID_STATE(), "Error creating TestArchetype, address is empty");
+		if (addr == 0x0) return "Error creating TestArchetype, address is empty";
 
 		//
 		// AGREEMENT
@@ -360,9 +363,9 @@ contract ActiveAgreementWorkflowTest {
 		address agreement1;
 		address agreement2;
 		agreement1 = agreementRegistry.createAgreement(addr, "TestAgreement1", this, EMPTY, EMPTY, EMPTY, EMPTY, 8, false, parties, EMPTY, governingAgreements);
-		if (agreement1 == 0x0) return (BaseErrors.INVALID_STATE(), "Unexpected error creating agreement1");
+		if (agreement1 == 0x0) return "Unexpected error creating agreement1";
 		agreement2 = agreementRegistry.createAgreement(addr, "TestAgreement2", this, EMPTY, EMPTY, EMPTY, EMPTY, 8, false, parties, EMPTY, governingAgreements);
-		if (agreement2 == 0x0) return (BaseErrors.INVALID_STATE(), "Unexpected error creating agreement2");
+		if (agreement2 == 0x0) return "Unexpected error creating agreement2";
 
 		//
 		// FORMATION / EXECUTION
@@ -370,67 +373,51 @@ contract ActiveAgreementWorkflowTest {
 		numberOfPIs = bpmService.getNumberOfProcessInstances();
 		ProcessInstance[3] memory pis; // to collect the created PIs
 		(error, addr) = agreementRegistry.startFormation(ActiveAgreement(agreement1));
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error starting the formation process 1 on agreement1");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		pis[0] = ProcessInstance(addr);
-		if (agreementRegistry.getTrackedFormationProcess(agreement1) == 0x0) return (BaseErrors.INVALID_STATE(), "There should be a tracked formation process for agreement1");
-		if (agreementRegistry.getTrackedExecutionProcess(agreement1) != 0x0) return (BaseErrors.INVALID_STATE(), "There should be NO tracked execution process for agreement1");
-		if (agreementRegistry.getTrackedFormationProcess(agreement1) != address(pis[0])) return (BaseErrors.INVALID_STATE(), "The tracked formation process should match the started formation PI for agreement1");
+		if (agreementRegistry.getTrackedFormationProcess(agreement1) == 0x0) return "$1";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement1) != 0x0) return "$1";
+		if (agreementRegistry.getTrackedFormationProcess(agreement1) != address(pis[0])) return "$1";
 		(error, addr) = agreementRegistry.startFormation(ActiveAgreement(agreement2));
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error starting the formation process 2 on agreement2");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		pis[1] = ProcessInstance(addr);
-		if (agreementRegistry.getTrackedFormationProcess(agreement2) == 0x0) return (BaseErrors.INVALID_STATE(), "There should be a tracked formation process for agreement2");
-		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != 0x0) return (BaseErrors.INVALID_STATE(), "There should be NO tracked execution process for agreement2");
-		if (agreementRegistry.getTrackedFormationProcess(agreement2) != address(pis[1])) return (BaseErrors.INVALID_STATE(), "The tracked formation process should match the started formation PI for agreement2");
+		if (agreementRegistry.getTrackedFormationProcess(agreement2) == 0x0) return "$1";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != 0x0) return "$1";
+		if (agreementRegistry.getTrackedFormationProcess(agreement2) != address(pis[1])) return "$1";
 
 		// sign agreement2 and move PI2 into execution phase
 		userAccount1.signAgreement(agreement2);
 		userAccount2.signAgreement(agreement2);
-		if (ActiveAgreement(agreement2).getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return (BaseErrors.INVALID_STATE(), "The agreement2 should be in EXECUTED after signing");
+		if (ActiveAgreement(agreement2).getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
 		error = pis[1].completeActivity(pis[1].getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error completing wait activity in formation process 2");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 	
-		if (bpmService.getNumberOfProcessInstances() != numberOfPIs+3) return (BaseErrors.INVALID_STATE(), "There should be 3 additional PIs in the system");
+		if (bpmService.getNumberOfProcessInstances() != numberOfPIs+3) return "$1";
 		numberOfPIs = bpmService.getNumberOfProcessInstances();
 		// the last added PI should be the execution process of agreement2
 		pis[2] = ProcessInstance(bpmService.getProcessInstanceAtIndex(numberOfPIs-1));
-		if (agreementRegistry.getTrackedExecutionProcess(agreement2) == 0x0) return (BaseErrors.INVALID_STATE(), "There should now be a tracked execution process for agreement2 after signing");
-		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != address(pis[2])) return (BaseErrors.INVALID_STATE(), "The tracked execution process for agreement2 should match the last PI");
-		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement1 should be active");
-		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement2 should be completed");
-		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return (BaseErrors.INVALID_STATE(), "The Execution PI for agreement2 should be active");
+		if (agreementRegistry.getTrackedExecutionProcess(agreement2) == 0x0) return "$1";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != address(pis[2])) return "$1";
+		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
+		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "$1";
+		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
 
 		// cancel the first agreement BEFORE its execution phase (uni-lateral cancellation)
 		userAccount2.cancelAgreement(agreement1);
-		if (ActiveAgreement(agreement1).getLegalState() != uint8(Agreements.LegalState.CANCELED)) return (BaseErrors.INVALID_STATE(), "agreement1 should be CANCELED");
-		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement1 should be aborted after canceling");
+		if (ActiveAgreement(agreement1).getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "agreement1 should be CANCELED";
+		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return "$1";
 		
 		// cancel the second agreement AFTER it reaches execution phase (multi-lateral cancellation required)
 		userAccount2.cancelAgreement(agreement2);
-		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement2 should still be completed after 1st cancellation");
-		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement2 should still be active after 1st cancellation");
+		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "$1";
+		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
 		userAccount1.cancelAgreement(agreement2);
-		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement2 should still be completed after 2nd cancellation");
-		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return (BaseErrors.INVALID_STATE(), "The Formation PI for agreement2 should be aborted after 2nd cancellation");
+		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "$1";
+		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return "$1";
 
-		return (BaseErrors.NO_ERROR(), SUCCESS);
+		return SUCCESS;
 	}
 
-	function bytes32ToString(bytes32 x) internal pure returns (string) {
-	    bytes memory bytesString = new bytes(32);
-	    uint charCount = 0;
-	    for (uint j = 0; j < 32; j++) {
-	        byte char = byte(bytes32(uint(x) * 2 ** (8 * j)));
-	        if (char != 0) {
-	            bytesString[charCount] = char;
-	            charCount++;
-	        }
-	    }
-	    bytes memory bytesStringTrimmed = new bytes(charCount);
-	    for (j = 0; j < charCount; j++) {
-	        bytesStringTrimmed[j] = bytesString[j];
-	    }
-	    return string(bytesStringTrimmed);
-	}
 }
 
 /**

--- a/contracts/src/bpm-model/test/ProcessModelRepositoryTest.sol
+++ b/contracts/src/bpm-model/test/ProcessModelRepositoryTest.sol
@@ -17,7 +17,7 @@ contract ProcessModelRepositoryTest {
 	uint error;
 	bytes32 EMPTY = "";
 	
-	function testRepository() external returns (uint, string) {
+	function testRepository() external returns (string) {
 
 		SystemOwned(db).transferSystemOwnership(repo);
 		AbstractDbUpgradeable(repo).acceptDatabase(db);
@@ -27,26 +27,26 @@ contract ProcessModelRepositoryTest {
 		ProcessModel pm3 = new DefaultProcessModel("testModel", "Test Model", [3,0,0], author, false, EMPTY, EMPTY);
 		
 		error = repo.addModel(pm1);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Adding model 1 failed.");
+		if (error != BaseErrors.NO_ERROR()) return "Adding model 1 failed.";
 		
-		if (repo.getModel("testModel") != address(pm1)) return (BaseErrors.INVALID_STATE(), "Version 1.0.0 should be the active one.");
+		if (repo.getModel("testModel") != address(pm1)) return "Version 1.0.0 should be the active one.";
 
 		error = repo.addModel(pm3);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Adding model 3 failed.");
+		if (error != BaseErrors.NO_ERROR()) return "Adding model 3 failed.";
 		
 		error = repo.addModel(pm2);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Adding model 2 failed.");
+		if (error != BaseErrors.NO_ERROR()) return "Adding model 2 failed.";
 
 		error = repo.activateModel(pm2);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error activating model 2."); 
+		if (error != BaseErrors.NO_ERROR()) return "Error activating model 2."; 
 		
-		if (repo.getModel("testModel") != address(pm2)) return (BaseErrors.INVALID_STATE(), "Version 2.0.0 should be the active one.");
+		if (repo.getModel("testModel") != address(pm2)) return "Version 2.0.0 should be the active one.";
 		
 		error = repo.activateModel(pm3);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Error activating model 3."); 
+		if (error != BaseErrors.NO_ERROR()) return "Error activating model 3."; 
 
-		if (repo.getModel("testModel") != address(pm3)) return (BaseErrors.INVALID_STATE(), "Version 3.0.0 should be the active one.");
+		if (repo.getModel("testModel") != address(pm3)) return "Version 3.0.0 should be the active one.";
 				
-		return (BaseErrors.NO_ERROR(), "success");
+		return "success";
 	}
 }

--- a/contracts/src/bpm-model/test/ProcessModelTest.sol
+++ b/contracts/src/bpm-model/test/ProcessModelTest.sol
@@ -16,57 +16,57 @@ contract ProcessModelTest {
 
 	bytes32 EMPTY = "";
 
-	function testProcessModel() external returns (uint, string) {
+	function testProcessModel() external returns (string) {
 		
 		uint error;
 		address newAddress;
 
 		ProcessModel pm = new DefaultProcessModel("testModel", "Test Model", [1,2,3], author, false, "hoardAddress", "hoardSecret");
-		if (pm.getId() != "testModel") return (BaseErrors.INVALID_STATE(), "ProcessModel ID not set correctly");
-		if (pm.getName() != "Test Model") return (BaseErrors.INVALID_STATE(), "ProcessModel Name not set correctly");
-		if (pm.getAuthor() != author) return (BaseErrors.INVALID_STATE(), "ProcessModel Author not set correctly");
-		if (pm.isPrivate() != false) return (BaseErrors.INVALID_STATE(), "ProcessModel expected to be public");
-		if (pm.major() != 1 || pm.minor() != 2 || pm.patch() != 3) return (BaseErrors.INVALID_STATE(), "ProcessModel Version not set correctly");
+		if (pm.getId() != "testModel") return "ProcessModel ID not set correctly";
+		if (pm.getName() != "Test Model") return "ProcessModel Name not set correctly";
+		if (pm.getAuthor() != author) return "ProcessModel Author not set correctly";
+		if (pm.isPrivate() != false) return "ProcessModel expected to be public";
+		if (pm.major() != 1 || pm.minor() != 2 || pm.patch() != 3) return "ProcessModel Version not set correctly";
 		bytes32 location;
 		bytes32 secret;
 		(location, secret) = pm.getDiagram();
-		if (location != "hoardAddress") return (BaseErrors.INVALID_STATE(), "wrong hoard location retrieved");
-		if (secret != "hoardSecret") return (BaseErrors.INVALID_STATE(), "wrong hoard secret retrieved");
+		if (location != "hoardAddress") return "wrong hoard location retrieved";
+		if (secret != "hoardSecret") return "wrong hoard secret retrieved";
 
 		(error, newAddress) = pm.createProcessDefinition("p1");
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error creating ProcessDefinition p1");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		ProcessDefinition pd = ProcessDefinition(newAddress);
 		
-		if (pm.getProcessDefinition("p1") != address(pd)) return (BaseErrors.INVALID_STATE(), "Returned ProcessDefinition address does not match.");
+		if (pm.getProcessDefinition("p1") != address(pd)) return "$1";
 
 		// test process interface handling
 		error = pm.addProcessInterface("AgreementFormation");
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unable to add process interface to model");
+		if (error != BaseErrors.NO_ERROR()) return "Unable to add process interface to model";
 		error = pd.addProcessInterfaceImplementation(0x0, "AgreementFormation");
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unable to add valid process interface to process definition.");
-		if (pm.getNumberOfProcessInterfaces() != 1) return (BaseErrors.INVALID_STATE(), "Wrong number of process interfaces");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (pm.getNumberOfProcessInterfaces() != 1) return "Wrong number of process interfaces";
 
 		// test participants
 		error = pm.addParticipant(participant1Id, 0x0, EMPTY, EMPTY, 0x0);
-		if (error != BaseErrors.INVALID_PARAM_VALUE()) return (error, "Expected INVALID_PARAM_VALUE setting conditional participant without dataPath");
+		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "$1";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, EMPTY, this);
-		if (error != BaseErrors.INVALID_PARAM_VALUE()) return (error, "Expected INVALID_PARAM_VALUE setting participant and conditional participant dataStorage");
+		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "$1";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, "storageId", 0x0);
-		if (error != BaseErrors.INVALID_PARAM_VALUE()) return (error, "Expected INVALID_PARAM_VALUE setting participant and conditional participant dataStorage ID");
+		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "$1";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, EMPTY, 0x0);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding valid participant1 to the model");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, EMPTY, 0x0);
-		if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return (error, "Expected RESOURCE_ALREADY_EXISTS adding participant twice");
+		if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
 
 		error = pm.addParticipant(participant2Id, 0x0, "Buyer", "myDataStore", 0x0);
-		if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding valid participant2 to the model");
+		if (error != BaseErrors.NO_ERROR()) return "$1";
 		if (pm.getConditionalParticipant("Buyer", "", 0x0) != "")
-			return (BaseErrors.INVALID_STATE(), "Retrieving invalid conditional participant Buyer should return nothing");
+			return "$1";
 		if (pm.getConditionalParticipant("", "", 0x0) != "")
-			return (BaseErrors.INVALID_STATE(), "Retrieving empty conditional participant should return nothing");
+			return "Retrieving empty conditional participant should return nothing";
 		if (pm.getConditionalParticipant("Buyer", "myDataStore", 0x0) != participant2Id)
-			return (BaseErrors.INVALID_STATE(), "Retrieving valid conditional participant should return participant2");
+			return "$1";
 
-		return (BaseErrors.NO_ERROR(), "success");
+		return "success";
 	}
 }

--- a/contracts/src/bpm-runtime/test/ApplicationRegistryTest.sol
+++ b/contracts/src/bpm-runtime/test/ApplicationRegistryTest.sol
@@ -23,7 +23,7 @@ contract ApplicationRegistryTest {
 
     bytes4 customCompletionFunction = bytes4(keccak256(abi.encodePacked("customComplete(address,bytes32,address)")));
 
-    function testApplicationRegistry() external returns (uint, string) {
+    function testApplicationRegistry() external returns (string) {
 
         uint error;
 
@@ -37,29 +37,29 @@ contract ApplicationRegistryTest {
 
         // add applications
         error = registry.addApplication(serviceApp1Id, BpmModel.ApplicationType.SERVICE, app1, bytes4(EMPTY), EMPTY);
-        if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding application1 to the registry");
+        if (error != BaseErrors.NO_ERROR()) return "$1";
         error = registry.addApplication(serviceApp1Id, BpmModel.ApplicationType.SERVICE, app1, bytes4(EMPTY), EMPTY);
-        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return (BaseErrors.INVALID_STATE(), "Expected RESOURCE_ALREADY_EXISTS for adding an already existing application1");
+        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
         error = registry.addApplication(serviceApp2Id, BpmModel.ApplicationType.SERVICE, app2, customCompletionFunction, EMPTY);
-        if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding an application2 to the registry");
+        if (error != BaseErrors.NO_ERROR()) return "$1";
 
-        if (registry.getNumberOfApplications() != 2) return (BaseErrors.INVALID_STATE(), "There should be 2 applications registered");
+        if (registry.getNumberOfApplications() != 2) return "There should be 2 applications registered";
 
         error = registry.addAccessPoint(serviceApp1Id, app1AccessPoint1, DataTypes.BYTES32(), BpmModel.Direction.IN);
-        if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding access point app1InData to ServiceApp1");
+        if (error != BaseErrors.NO_ERROR()) return "$1";
         error = registry.addAccessPoint(serviceApp1Id, app1AccessPoint2, DataTypes.STRING(), BpmModel.Direction.OUT);
-        if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding access point app1OutData to ServiceApp1");
+        if (error != BaseErrors.NO_ERROR()) return "$1";
         error = registry.addAccessPoint(serviceApp1Id, app1AccessPoint1, DataTypes.UINT(), BpmModel.Direction.IN);
-        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return (BaseErrors.INVALID_STATE(), "Expected error when trying to add duplicate access point");
+        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
         
-        if (registry.getNumberOfAccessPoints(serviceApp1Id) != 2) return (BaseErrors.INVALID_STATE(), "Wrong access point count for ServiceApp1");
+        if (registry.getNumberOfAccessPoints(serviceApp1Id) != 2) return "Wrong access point count for ServiceApp1";
 
         uint8 dataType;
         BpmModel.Direction direction;
 
         (dataType, direction) = registry.getAccessPointData(serviceApp1Id, app1AccessPoint1);
-        if (dataType != DataTypes.BYTES32()) return (BaseErrors.INVALID_STATE(), "Expected bytes32 dataType for access point app1AccessPoint1");
-        if (direction != BpmModel.Direction.IN) return (BaseErrors.INVALID_STATE(), "Expected direction IN for access point app1AccessPoint1");
+        if (dataType != DataTypes.BYTES32()) return "$1";
+        if (direction != BpmModel.Direction.IN) return "$1";
 
         uint8 myType;
         address location;
@@ -68,20 +68,20 @@ contract ApplicationRegistryTest {
         uint accessPointCount;
 
         (myType, location, method, webForm, accessPointCount) = registry.getApplicationData(serviceApp1Id);
-        if (myType != uint8(BpmModel.ApplicationType.SERVICE)) return (BaseErrors.INVALID_STATE(), "app1 wrong applicationType");
-        if (location != address(app1)) return (BaseErrors.INVALID_STATE(), "app1 wrong location");
-        if (method != bytes4(EMPTY)) return (BaseErrors.INVALID_STATE(), "app1 wrong completion function");
-        if (webForm != "") return (BaseErrors.INVALID_STATE(), "app1 wrong webForm");
-        if (accessPointCount != 2) return (BaseErrors.INVALID_STATE(), "app1 wrong accessPointCount");
+        if (myType != uint8(BpmModel.ApplicationType.SERVICE)) return "app1 wrong applicationType";
+        if (location != address(app1)) return "app1 wrong location";
+        if (method != bytes4(EMPTY)) return "app1 wrong completion function";
+        if (webForm != "") return "app1 wrong webForm";
+        if (accessPointCount != 2) return "app1 wrong accessPointCount";
 
         (myType, location, method, webForm, accessPointCount) = registry.getApplicationData(serviceApp2Id);
-        if (myType != uint8(BpmModel.ApplicationType.SERVICE)) return (BaseErrors.INVALID_STATE(), "app2 wrong applicationType");
-        if (location != address(app2)) return (BaseErrors.INVALID_STATE(), "app2 wrong location");
-        if (method != customCompletionFunction) return (BaseErrors.INVALID_STATE(), "app2 wrong completion function");
-        if (webForm != "") return (BaseErrors.INVALID_STATE(), "app2 wrong webForm");
-        if (accessPointCount != 0) return (BaseErrors.INVALID_STATE(), "app1 wrong accessPointCount");
+        if (myType != uint8(BpmModel.ApplicationType.SERVICE)) return "app2 wrong applicationType";
+        if (location != address(app2)) return "app2 wrong location";
+        if (method != customCompletionFunction) return "app2 wrong completion function";
+        if (webForm != "") return "app2 wrong webForm";
+        if (accessPointCount != 0) return "app1 wrong accessPointCount";
 
-        return (BaseErrors.NO_ERROR(), SUCCESS);
+        return SUCCESS;
     }
     
 }

--- a/contracts/src/bpm-runtime/test/ServiceUpgradeabilityTest.sol
+++ b/contracts/src/bpm-runtime/test/ServiceUpgradeabilityTest.sol
@@ -21,7 +21,7 @@ contract ServiceUpgradeabilityTest {
 
 	bytes4 customCompletionFunction = bytes4(keccak256(abi.encodePacked("customComplete(address,bytes32,address)")));
 
-	function testServiceUpgradeability() external returns (uint, string) {
+	function testServiceUpgradeability() external returns (string) {
 
 			uint error;
 
@@ -34,17 +34,17 @@ contract ServiceUpgradeabilityTest {
 			TestApplication app2 = new TestApplication();
 
 			error = registryV1.addApplication(serviceApp1Id, BpmModel.ApplicationType.SERVICE, app1, bytes4(EMPTY), EMPTY);
-			if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding application1 to registryV1");
+			if (error != BaseErrors.NO_ERROR()) return "$1";
 			error = registryV1.addApplication(serviceApp2Id, BpmModel.ApplicationType.SERVICE, app2, customCompletionFunction, EMPTY);
-			if (error != BaseErrors.NO_ERROR()) return (error, "Unexpected error adding application2 to registryV1");
-			if (registryV1.getNumberOfApplications() != 2) return (BaseErrors.INVALID_STATE(), "There should be 2 applications registered via registryV1");
+			if (error != BaseErrors.NO_ERROR()) return "$1";
+			if (registryV1.getNumberOfApplications() != 2) return "$1";
 
 			ApplicationRegistry registryV2 = new  DefaultApplicationRegistry();
-			if (!AbstractDbUpgradeable(registryV1).migrateTo(registryV2)) return (error, "Unexpected error while migrating from registryV1 to registryV2");
-			if (registryV2.getNumberOfApplications() != 2) return (BaseErrors.INVALID_STATE(), "There should be 2 applications registered via registryV2");
-			if (registryDb.getSystemOwner() != address(registryV2)) return (BaseErrors.INVALID_STATE(), "ApplicationRegistryDb owner is not set to registryV2");
+			if (!AbstractDbUpgradeable(registryV1).migrateTo(registryV2)) return "$1";
+			if (registryV2.getNumberOfApplications() != 2) return "$1";
+			if (registryDb.getSystemOwner() != address(registryV2)) return "$1";
 
-			return (BaseErrors.NO_ERROR(), SUCCESS);
+			return SUCCESS;
 	}
 }
 

--- a/contracts/src/commons-standards/test/ERC165Test.sol
+++ b/contracts/src/commons-standards/test/ERC165Test.sol
@@ -9,23 +9,23 @@ contract ERC165Test {
 
     bytes4 interfaceMyContract = bytes4(keccak256(abi.encodePacked("someFunction()"))) ^ bytes4(keccak256(abi.encodePacked("someOtherFunction(address)")));
 
-    function testERC165() external returns (uint, string) {
+    function testERC165() external returns (string) {
 
         address myImplAddress = new MyContract();
 
         // fail
         if (myImplAddress.call(bytes4(keccak256(abi.encodePacked("addIllegalSupport()")))))
-            return (BaseErrors.INVALID_STATE(), "Custom contract should throw when adding illegal 0xffffffff interface");
+            return "$1";
         if (ERC165Utils.implementsInterface(myImplAddress, bytes4(keccak256(abi.encodePacked("unknownFunction(bytes32)")))) == true)
-            return (BaseErrors.INVALID_STATE(), "Custom contract should not support an unknown interface");
+            return "$1";
 
         // success
         if (ERC165Utils.implementsInterface(myImplAddress, 0x01ffc9a7) == false)
-            return (BaseErrors.INVALID_STATE(), "Custom contract should support the ERC165 interface");
+            return "Custom contract should support the ERC165 interface";
         if (ERC165Utils.implementsInterface(myImplAddress, interfaceMyContract) == false)
-            return (BaseErrors.INVALID_STATE(), "Custom contract should support the custom interface");
+            return "Custom contract should support the custom interface";
 
-        return (BaseErrors.NO_ERROR(), "success");
+        return "success";
     }
 
 }

--- a/contracts/src/commons-utils/TypeUtilsAPI.sol
+++ b/contracts/src/commons-utils/TypeUtilsAPI.sol
@@ -28,20 +28,11 @@ library TypeUtilsAPI {
 	function isEmpty(bytes32 _value) public pure returns (bool);
 
     /**
-     * @dev Converts an address to its bytes representation.
-     * @param x the address
-     * @return b the bytes representation
-     */
-     // NOTE: temporarily removed. see (https://github.com/eris-ltd/eris-db/issues/474)
-//    function toBytes(address x) internal constant returns (bytes b);
-
-    /**
      * @dev Converts bytes32 to string
      * @param x bytes32
      * @return the string representation
      */
-     // NOTE: temporarily removed. see (https://github.com/eris-ltd/eris-db/issues/474)
-//    function toString (bytes32 x) constant returns (string);
+    function toString (bytes32 x) public pure returns (string);
     
     /**
      * @dev Converts the given string to bytes32. If the string is longer than
@@ -50,14 +41,5 @@ library TypeUtilsAPI {
      * @return the bytes32 representation
      */
     function toBytes32(string s) public pure returns (bytes32 result);
-
-    /**
-     * @dev Concatenates two bytes parameters into one
-     * @param self the first bytes part
-     * @param bts the second bytes part
-     * @return newBts the concatenation result
-     */
-     // NOTE: temporarily removed. see (https://github.com/eris-ltd/eris-db/issues/474)
-//    function concat(bytes memory self, bytes memory bts) internal constant returns (bytes newBts);
 
 }

--- a/contracts/src/commons-utils/TypeUtilsImpl.sol
+++ b/contracts/src/commons-utils/TypeUtilsImpl.sol
@@ -71,59 +71,27 @@ library TypeUtilsImpl {
     }
 
     /**
-     * @dev Converts an address to its bytes representation.
-     * @param x the address
-     * @return b the bytes representation
-     */
-     // NOTE: temporarily removed. see (https://github.com/eris-ltd/eris-db/issues/474)
-//    function toBytes(address x) internal public pure returns (bytes b) {
-//        b = new bytes(20);
-//        for (uint i = 0; i < 20; i++)
-//            b[i] = byte(uint8(uint(x) / (2**(8*(19 - i)))));
-//    }
-
-    /**
      * @dev Converts bytes32 to string
      * @param x bytes32
      * @return the string representation
      */
-     // NOTE: temporarily removed. see (https://github.com/eris-ltd/eris-db/issues/474)
-//    function toString (bytes32 x) public pure returns (string) {
-//        bytes memory bytesString = new bytes(32);
-//        uint charCount = 0;
-//        for (uint j = 0; j < 32; j++) {
-//            byte char = byte(bytes32(uint(x) * 2 ** (8 * j)));
-//            if (char != 0) {
-//                bytesString[charCount] = char;
-//                charCount++;
-//            }
-//        }
-//        bytes memory resultBytes = new bytes(charCount);
-//        for (j = 0; j < charCount; j++) {
-//            resultBytes[j] = bytesString[j];
-//        }
-//
-//        return string(resultBytes);
-//    }
+    function toString (bytes32 x) public pure returns (string) {
+	    bytes memory bytesString = new bytes(32);
+	    uint charCount = 0;
+	    for (uint j = 0; j < 32; j++) {
+	        byte char = byte(bytes32(uint(x) * 2 ** (8 * j)));
+	        if (char != 0) {
+	            bytesString[charCount] = char;
+	            charCount++;
+	        }
+	    }
+	    bytes memory bytesStringTrimmed = new bytes(charCount);
+	    for (j = 0; j < charCount; j++) {
+	        bytesStringTrimmed[j] = bytesString[j];
+	    }
+	    return string(bytesStringTrimmed);
+    }
 
-// https://ethereum.stackexchange.com/questions/2519/how-to-convert-a-bytes32-to-string
-//     function bytes32ToString(bytes32 x) public pure returns (string) {
-//         bytes memory bytesString = new bytes(32);
-//         uint charCount = 0;
-//         for (uint j = 0; j < 32; j++) {
-//             byte char = byte(bytes32(uint(x) * 2 ** (8 * j)));
-//             if (char != 0) {
-//                 bytesString[charCount] = char;
-//                 charCount++;
-//             }
-//         }
-//         bytes memory bytesStringTrimmed = new bytes(charCount);
-//         for (j = 0; j < charCount; j++) {
-//             bytesStringTrimmed[j] = bytesString[j];
-//         }
-//         return string(bytesStringTrimmed);
-//     }
-    
     /**
      * @dev Converts the given string to bytes32. If the string is longer than
      * 32 byte-sized characters (depends on encoding and character-set), it will be truncated.
@@ -135,47 +103,5 @@ library TypeUtilsImpl {
     	    result := mload(add(s, 32))
     	}
     }
-
-    /**
-     * @dev Concatenates two bytes parameters into one
-     * @param self the first bytes part
-     * @param bts the second bytes part
-     * @return newBts the concatenation result
-     */
-     // NOTE: temporarily removed. see (https://github.com/eris-ltd/eris-db/issues/474)
-//    function concat(bytes memory self, bytes memory bts) internal public pure returns (bytes newBts) {
-//        uint totLen = self.length + bts.length;
-//        if (totLen == 0)
-//            return;
-//        newBts = new bytes(totLen);
-//        assembly {
-//                let i := 0
-//                let inOffset := 0
-//                let outOffset := add(newBts, 0x20)
-//                let words := 0
-//                let tag := tag_bts
-//            tag_self:
-//                inOffset := add(self, 0x20)
-//                words := div(add(mload(self), 31), 32)
-//                jump(tag_loop)
-//            tag_bts:
-//                i := 0
-//                inOffset := add(bts, 0x20)
-//                outOffset := add(newBts, add(0x20, mload(self)))
-//                words := div(add(mload(bts), 31), 32)
-//                tag := tag_end
-//            tag_loop:
-//                jumpi(tag, gt(i, words))
-//                {
-//                    let offset := mul(i, 32)
-//                    outOffset := add(outOffset, offset)
-//                    mstore(outOffset, mload(add(inOffset, offset)))
-//                    i := add(i, 1)
-//                }
-//                jump(tag_loop)
-//            tag_end:
-//                mstore(add(newBts, add(totLen, 0x20)), 0)
-//        }
-//    }
 
 }

--- a/contracts/src/commons-utils/test/TypeUtilsTest.sol
+++ b/contracts/src/commons-utils/test/TypeUtilsTest.sol
@@ -48,15 +48,13 @@ contract TypeUtilsTest {
     	return "success";
     }
 
-// Commented due to https://github.com/eris-ltd/eris-db/issues/474	
-//	function testAddressToBytes(address addr) constant returns (bytes) {
-//		return addr.toBytes();
-//	}
-
-// Commented due to https://github.com/eris-ltd/eris-db/issues/474	
-//	function testBytes32ToString(bytes32 _input) constant returns (string) {
-//		return _input.toString();
-//	}
+	function testBytes32ToString() external pure returns (string) {
+		bytes32 input = "Rumpelstiltskin";
+		string memory expectedResult = "Rumpelstiltskin";
+		if (keccak256(abi.encodePacked(input.toString())) != keccak256(abi.encodePacked(expectedResult)))
+			return "The converted input bytes32 should match the expected result string";
+		return "success";
+	}
 
 	function testStringToBytes32() external pure returns (string) {
 		string memory s = "blabla";
@@ -71,9 +69,4 @@ contract TypeUtilsTest {
 		return "success";
 	}
 	
-// Commented due to https://github.com/eris-ltd/eris-db/issues/474	
-//	function testConcatBytes(bytes b1, bytes b2) constant returns (bytes) {
-//		return TypeUtilsAPI.concat(b1, b2);
-//	}
-
 }

--- a/contracts/src/test-agreements.yaml
+++ b/contracts/src/test-agreements.yaml
@@ -138,9 +138,9 @@ jobs:
 
 - name: assertActiveAgreementSetup
   assert:
-    key: $testActiveAgreementSetup.0
+    key: $testActiveAgreementSetup
     relation: eq
-    val: 1
+    val: success
 
 - name: testActiveAgreementSigning
   call:
@@ -150,9 +150,9 @@ jobs:
 
 - name: assertActiveAgreementSigning
   assert:
-    key: $testActiveAgreementSigning.0
+    key: $testActiveAgreementSigning
     relation: eq
-    val: 1
+    val: success
 
 - name: testActiveAgreementCancellation
   call:
@@ -162,9 +162,9 @@ jobs:
 
 - name: assertActiveAgreementCancellation
   assert:
-    key: $testActiveAgreementCancellation.0
+    key: $testActiveAgreementCancellation
     relation: eq
-    val: 1
+    val: success
 
 
 # ActiveAgreementRegistryTest
@@ -182,9 +182,9 @@ jobs:
 
 - name: assertActiveAgreementRegistry
   assert:
-    key: $testActiveAgreementRegistry.0
+    key: $testActiveAgreementRegistry
     relation: eq
-    val: 1
+    val: success
 
 - name: testAgreementCollections
   call:
@@ -194,9 +194,9 @@ jobs:
 
 - name: assertAgreementCollections
   assert:
-    key: $testAgreementCollections.0
+    key: $testAgreementCollections
     relation: eq
-    val: 1
+    val: success
 
 - name: testGoverningAgreements
   call:
@@ -446,9 +446,9 @@ jobs:
 
 - name: assertExecutedAgreementWorkflow
   assert:
-    key: $testExecutedAgreementWorkflow.0
+    key: $testExecutedAgreementWorkflow
     relation: eq
-    val: 1
+    val: success
 
 - name: testCanceledAgreementWorkflow
   call:
@@ -458,6 +458,6 @@ jobs:
 
 - name: assertCanceledAgreementWorkflow
   assert:
-    key: $testCanceledAgreementWorkflow.0
+    key: $testCanceledAgreementWorkflow
     relation: eq
-    val: 1
+    val: success

--- a/contracts/src/test-bpm-model.yaml
+++ b/contracts/src/test-bpm-model.yaml
@@ -102,9 +102,9 @@ jobs:
 
 - name: assertProcessModelRepository
   assert:
-    key: $testProcessModelRepository.0
+    key: $testProcessModelRepository
     relation: eq
-    val: 1
+    val: success
 
 - name: ProcessModelTest
   deploy:
@@ -120,9 +120,9 @@ jobs:
 
 - name: assertProcessModel
   assert:
-    key: $testProcessModel.0
+    key: $testProcessModel
     relation: eq
-    val: 1
+    val: success
 
 - name: ProcessDefinitionTest
   deploy:
@@ -138,9 +138,9 @@ jobs:
 
 - name: assertProcessDefinition
   assert:
-    key: $testProcessDefinition.0
+    key: $testProcessDefinition
     relation: eq
-    val: 1
+    val: success
 
 - name: testTransitionConditionResolution
   call:

--- a/contracts/src/test-bpm-runtime.yaml
+++ b/contracts/src/test-bpm-runtime.yaml
@@ -57,9 +57,9 @@ jobs:
 
 - name: assertServiceUpgradeability
   assert:
-    key: $testServiceUpgradeability.0
+    key: $testServiceUpgradeability
     relation: eq
-    val: 1
+    val: success
 
 ##########
 # ApplicationRegistry Tests
@@ -78,9 +78,9 @@ jobs:
 
 - name: assertApplicationRegistry
   assert:
-    key: $testApplicationRegistry.0
+    key: $testApplicationRegistry
     relation: eq
-    val: 1
+    val: success
 
 ##########
 # BPM Tests
@@ -153,7 +153,7 @@ jobs:
   deploy:
     contract: BpmServiceTest.bin
     instance: BpmServiceTest
-    libraries: ErrorsLib:$ErrorsLib, ArrayUtilsAPI:$ArrayUtilsImpl, MappingsLib:$MappingsLib, BpmRuntimeLib:$BpmRuntimeLib, DataStorageUtils:$DataStorageUtils
+    libraries: ErrorsLib:$ErrorsLib, ArrayUtilsAPI:$ArrayUtilsImpl, TypeUtilsAPI:$TypeUtilsImpl, MappingsLib:$MappingsLib, BpmRuntimeLib:$BpmRuntimeLib, DataStorageUtils:$DataStorageUtils
 
 - name: setAppRegistry
   call:
@@ -249,9 +249,9 @@ jobs:
 
 - name: assertInternalProcessExecution
   assert:
-    key: $testInternalProcessExecution.0
+    key: $testInternalProcessExecution
     relation: eq
-    val: 1
+    val: success
 
 - name: testGatewayRouting
   call:
@@ -273,9 +273,9 @@ jobs:
 
 - name: assertSequentialServiceApplications
   assert:
-    key: $testSequentialServiceApplications.0
+    key: $testSequentialServiceApplications
     relation: eq
-    val: 1
+    val: success
 
 - name: testParticipantResolution
   call:
@@ -285,9 +285,9 @@ jobs:
 
 - name: assertParticipantResolution
   assert:
-    key: $testParticipantResolution.0
+    key: $testParticipantResolution
     relation: eq
-    val: 1
+    val: success
 
 - name: testSequentialProcessWithUserTask
   call:
@@ -297,9 +297,9 @@ jobs:
 
 - name: assertSequentialProcessWithUserTask
   assert:
-    key: $testSequentialProcessWithUserTask.0
+    key: $testSequentialProcessWithUserTask
     relation: eq
-    val: 1
+    val: success
 
 - name: testProcessAbort
   call:
@@ -309,9 +309,9 @@ jobs:
 
 - name: assertProcessAbort
   assert:
-    key: $testProcessAbort.0
+    key: $testProcessAbort
     relation: eq
-    val: 1
+    val: success
 
 - name: testMultiInstanceUserTask
   call:
@@ -321,9 +321,9 @@ jobs:
 
 - name: assertMultiInstanceUserTask
   assert:
-    key: $testMultiInstanceUserTask.0
+    key: $testMultiInstanceUserTask
     relation: eq
-    val: 1
+    val: success
 
 ## NOTE: subprocesses currently not yet supported. Tests are failing
 
@@ -335,6 +335,6 @@ jobs:
 
 # - name: assertSubprocesses
 #   assert:
-#     key: $testSubprocesses.0
+#     key: $testSubprocesses
 #     relation: eq
-#     val: 1
+#     val: success

--- a/contracts/src/test-commons-standards.yaml
+++ b/contracts/src/test-commons-standards.yaml
@@ -43,9 +43,9 @@ jobs:
 
 - name: assertERC165Test
   assert:
-    key: $testERC165.0
+    key: $testERC165
     relation: eq
-    val: 1
+    val: success
 
 #####
 # IsoCountries Test

--- a/contracts/src/test-commons-utils.yaml
+++ b/contracts/src/test-commons-utils.yaml
@@ -59,36 +59,20 @@ jobs:
     relation: eq
     val: success
 
-# address -> bytes
-# Commented due to https://github.com/eris-ltd/eris-db/issues/474  
-# - name: testAddressToBytes
-#     call:
-#       destination: $TypeUtilsLibTest
-#       function: testAddressToBytes
-#       data: [$TypeUtilsLibTest]
-# 
-# - name: assertAddressToBytes
-#     assert:
-#       key: $testAddressToBytes
-#       relation: eq
-#       val: $TypeUtilsLibTest
-
 # bytes32 -> string
-# Commented due to https://github.com/eris-ltd/eris-db/issues/474  
-# - name: testBytes32ToString
-#     call:
-#       destination: $TypeUtilsLibTest
-#       function: testBytes32ToString
-#       data: [Rumpelstiltskin]
-# 
-# - name: assertBytes32ToString
-#     assert:
-#       key: $testBytes32ToString
-#       relation: eq
-#       val: Rumpelstiltskin
+- name: testBytes32ToString
+  call:
+    destination: $TypeUtilsLibTest
+    bin: TypeUtilsTest
+    function: testBytes32ToString
+
+- name: assertBytes32ToString
+  assert:
+    key: $testBytes32ToString
+    relation: eq
+    val: success
 
 # string -> bytes32
-# Commented due to https://github.com/eris-ltd/eris-db/issues/474  
 - name: testStringToBytes32
   call:
     destination: $TypeUtilsLibTest
@@ -100,19 +84,6 @@ jobs:
     key: $testStringToBytes32
     relation: eq
     val: success
-
-# Commented due to https://github.com/eris-ltd/eris-db/issues/474  
-# - name: testConcatBytes
-#     call:
-#       destination: $TypeUtilsLibTest
-#       function: testConcatBytes
-#       data: ["Hello ", "World"]
-# 
-# - name: assertConcatBytes
-#     assert:
-#       key: $testConcatBytes
-#       relation: eq
-#       val: "Hello World"
 
 #####
 # ArrayUtils Test


### PR DESCRIPTION
We've had different approaches to unit testing over time. This PR consolidates all test returns under the simple approach of returning a string from each test function, because the return of uint values as error codes has lost most of its benefit since switching more and more to revert/require with reasons.
Also, some commented out functions in TypeUtilsAPI were removed and the implementation of `bytes32ToString` was moved there from multiple tests.

Signed-off-by: Jan Hendrik Scheufen <j.h.scheufen@gmail.com>