### PR TITLE
Default department in organizations as catch-all

### DIFF
--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -207,7 +207,7 @@ const getOrganization = orgAddr => getContract(global.__abi, global.__monax_bund
  */
 const createOrganization = org => new Promise((resolve, reject) => {
   log.trace(`Creating organization with: ${JSON.stringify(org)}`);
-  appManager.contracts['ParticipantsManager'].factory.createOrganization(org.approvers ? org.approvers : [], (error, data) => {
+  appManager.contracts['ParticipantsManager'].factory.createOrganization(org.approvers ? org.approvers : [], "TODO_DEFAULT_DEPARTMENT_LABEL", (error, data) => {
     if (error || !data.raw) return reject(boom.badImplementation(`Failed to create organization ${org.name}: ${error}`));
     if (parseInt(data.raw[0], 10) === 1002) return reject(boom.badRequest('Organization id must be unique'));
     if (parseInt(data.raw[0], 10) !== 1) {

--- a/api/sqlsol/BpmService.json
+++ b/api/sqlsol/BpmService.json
@@ -13,6 +13,11 @@
       "dependent": "processAddress",
       "deserialize": "getActivityInstanceAtIndex",
       "len": { "call": "getNumberOfActivityInstances", "field": "size" }
+    },
+    "addressScopeKey": {
+      "dependent": "processAddress",
+      "deserialize": "getAddressScopeKeyAtIndex",
+      "len": { "call": "getNumberOfAddressScopes", "field": "size" }
     }
   },
   "tables": {
@@ -27,6 +32,10 @@
     "PROCESS_DATA": {
       "call": "getProcessDataDetails",
       "keys": ["processAddress", "dataId"]
+    },
+    "PROCESS_INSTANCE_ADDRESS_SCOPES": {
+      "call": "getAddressScopeDetails",
+      "keys": ["processAddress", "addressScopeKey"]
     }
   }
 }

--- a/contracts/src/agreements/AgreementsAPI.sol
+++ b/contracts/src/agreements/AgreementsAPI.sol
@@ -54,12 +54,15 @@ library AgreementsAPI {
         for (i=0; i<size; i++) {
             current = _agreement.getPartyAtIndex(i);
             if (ERC165Utils.implementsInterface(current, Governance.ERC165_ID_Organization())) {
-                if (Organization(current).authorizeUser(msg.sender, bytes32(""))) {
+                // The agreement might have a scope set for the agreement parties reserved field that represents the signatories
+                // that needs to be used to authorize against the organization
+                bytes32 scope = _agreement.resolveAddressScope(current, _agreement.DATA_FIELD_AGREEMENT_PARTIES(), _agreement);
+                if (Organization(current).authorizeUser(msg.sender, scope)) {
                     actor = msg.sender;
                     party = current;
                     return;
                 }
-                else if (Organization(current).authorizeUser(tx.origin, bytes32(""))) {
+                else if (Organization(current).authorizeUser(tx.origin, scope)) {
                     actor = tx.origin;
                     party = current;
                     return;

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -13,6 +13,7 @@ contract ActiveAgreementTest {
   
   	string constant SUCCESS = "success";
 	string constant EMPTY_STRING = "";
+	bytes32 constant EMPTY = "";
 
 	DefaultArchetype archetype;
 	address falseAddress = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
@@ -77,10 +78,10 @@ contract ActiveAgreementTest {
 
 		// set up the parties.
 		// Signer1 is a direct signer
-		// Signer 2 is signing on behalf of an organization
+		// Signer 2 is signing on behalf of an organization (default department)
 		address[10] memory emptyAddressArray;
 		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray, EMPTY_STRING);
-		if (!org1.addUser(signer2)) return "Unable to add user account to organization";
+		if (!org1.addUserToDepartment(signer2, EMPTY)) return "Unable to add user account to organization";
 		delete parties;
 		parties.push(address(signer1));
 		parties.push(address(org1));

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -11,7 +11,8 @@ import "agreements/DefaultArchetype.sol";
 
 contract ActiveAgreementTest {
   
-  string constant SUCCESS = "success";
+  	string constant SUCCESS = "success";
+	string constant EMPTY_STRING = "";
 
 	DefaultArchetype archetype;
 	address falseAddress = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
@@ -78,7 +79,7 @@ contract ActiveAgreementTest {
 		// Signer1 is a direct signer
 		// Signer 2 is signing on behalf of an organization
 		address[10] memory emptyAddressArray;
-		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray);
+		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray, EMPTY_STRING);
 		if (!org1.addUser(signer2)) return "Unable to add user account to organization";
 		delete parties;
 		parties.push(address(signer1));

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -61,9 +61,9 @@ contract ActiveAgreementTest {
 		// test parties array retrieval via DataStorage (needed for workflow participants)
 		address[100] memory partiesArr = agreement.getDataValueAsAddressArray(DATA_FIELD_AGREEMENT_PARTIES);
 		address[100] memory bogusArr = agreement.getDataValueAsAddressArray(bogusId);
-		if (partiesArr[0] != address(signer1)) return "$1";
-		if (bogusArr[0] != address(0xCcD5bA65282C3dafB69b19351C7D5B77b9fDDCA6)) return "$1";
-		if (agreement.getNumberOfArrayEntries(DATA_FIELD_AGREEMENT_PARTIES, false) != agreement.getNumberOfParties()) return "$1";
+		if (partiesArr[0] != address(signer1)) return "address[] retrieval via DATA_FIELD_AGREEMENT_PARTIES did not yield first element as expected";
+		if (bogusArr[0] != address(0xCcD5bA65282C3dafB69b19351C7D5B77b9fDDCA6)) return "address[] retrieval via regular ID did not yield first element as expected";
+		if (agreement.getNumberOfArrayEntries(DATA_FIELD_AGREEMENT_PARTIES, false) != agreement.getNumberOfParties()) return "Array size count via DATA_FIELD_AGREEMENT_PARTIES did not match the number of parties";
 
 		return SUCCESS;
 	}
@@ -95,8 +95,8 @@ contract ActiveAgreementTest {
 		if (address(agreement).call(bytes4(keccak256(abi.encodePacked("sign()")))))
 			return "Signing from test address should REVERT due to invalid actor";
 		(signee, timestamp) = agreement.getSignatureDetails(signer1);
-		if (timestamp != 0) return "$1";
-		if (AgreementsAPI.isFullyExecuted(agreement)) return "$1";
+		if (timestamp != 0) return "Signature timestamp for signer1 should be 0 before signing";
+		if (AgreementsAPI.isFullyExecuted(agreement)) return "AgreementsAPI.isFullyExecuted should be false before signing";
 		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return "Agreement legal state should NOT be EXECUTED";
 
 		// Signing with Signer1 as party
@@ -104,9 +104,9 @@ contract ActiveAgreementTest {
 		if (!agreement.isSignedBy(signer1)) return "Agreement should be signed by signer1";
 		(signee, timestamp) = agreement.getSignatureDetails(signer1);
 		if (signee != address(signer1)) return "Signee for signer1 should be signer1";
-		if (timestamp == 0) return "$1";
-		if (AgreementsAPI.isFullyExecuted(agreement)) return "$1";
-		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return "$1";
+		if (timestamp == 0) return "Signature timestamp for signer1 should be set after signing";
+		if (AgreementsAPI.isFullyExecuted(agreement)) return "AgreementsAPI.isFullyExecuted should be false after signer1";
+		if (agreement.getLegalState() == uint8(Agreements.LegalState.EXECUTED)) return "Agreement legal state should NOT be EXECUTED after signer1";
 
 		// Signing with Signer2 via the organization
 		signer2.signAgreement(agreement);
@@ -114,9 +114,9 @@ contract ActiveAgreementTest {
 		if (agreement.isSignedBy(org1)) return "Agreement should NOT be signed by org1";
 		(signee, timestamp) = agreement.getSignatureDetails(org1);
 		if (signee != address(signer2)) return "Signee for org1 should be signer1";
-		if (timestamp == 0) return "$1";
-		if (!AgreementsAPI.isFullyExecuted(agreement)) return "$1";
-		if (agreement.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
+		if (timestamp == 0) return "Signature timestamp for org1 should be set after signing";
+		if (!AgreementsAPI.isFullyExecuted(agreement)) return "AgreementsAPI.isFullyExecuted should be true after signer2";
+		if (agreement.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "Agreement legal state should be EXECUTED after signer2";
 
 		return SUCCESS;
 	}
@@ -146,16 +146,16 @@ contract ActiveAgreementTest {
 
 		// Agreement1 is canceled during formation
 		signer2.cancelAgreement(agreement1);
-		if (agreement1.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "$1";
+		if (agreement1.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "Agreement1 legal state should be CANCELED after unilateral cancellation in formation";
 
 		// Agreement2 is canceled during execution
 		signer1.signAgreement(agreement2);
 		signer2.signAgreement(agreement2);
-		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
+		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "Agreemen2 legal state should be EXECUTED after parties signed";
 		signer1.cancelAgreement(agreement2);
-		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
+		if (agreement2.getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "Agreement2 legal state should still be EXECUTED after unilateral cancellation";
 		signer2.cancelAgreement(agreement2);
-		if (agreement2.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "$1";
+		if (agreement2.getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "Agreement2 legal state should be CANCELED after bilateral cancellation";
 
 		return SUCCESS;
 	}

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -183,7 +183,7 @@ contract ActiveAgreementWorkflowTest {
 
 		org1 = new DefaultOrganization(approvers, EMPTY_STRING);
 		org2 = new DefaultOrganization(approvers, EMPTY_STRING);
-		org1.addUser(userAccount2);
+		org1.addUserToDepartment(userAccount2, EMPTY);
 		org2.addDepartment(departmentId1, "Department 1");
 		org2.addUserToDepartment(userAccount3, departmentId1);
 

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -28,7 +28,9 @@ import "agreements/AgreementSignatureCheck.sol";
 contract ActiveAgreementWorkflowTest {
 
 	using TypeUtilsAPI for bytes32;
-	
+
+	string constant EMPTY_STRING = "";
+
 	// test data
 	bytes32 activityId1 = "activity1";
 	bytes32 activityId2 = "activity2";
@@ -179,8 +181,8 @@ contract ActiveAgreementWorkflowTest {
 		userAccount2 = new AgreementPartyAccount(user2Id, this, address(0));
 		userAccount3 = new AgreementPartyAccount(user3Id, this, address(0));
 
-		org1 = new DefaultOrganization(approvers);
-		org2 = new DefaultOrganization(approvers);
+		org1 = new DefaultOrganization(approvers, EMPTY_STRING);
+		org2 = new DefaultOrganization(approvers, EMPTY_STRING);
 		org1.addUser(userAccount2);
 		org2.addDepartment(departmentId1, "Department 1");
 		org2.addUserToDepartment(userAccount3, departmentId1);

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -166,7 +166,7 @@ contract ActiveAgreementWorkflowTest {
 		TestSignatureCheck signatureCheckApp = new TestSignatureCheck();
 		applicationRegistry.addApplication("AgreementSignatureCheck", BpmModel.ApplicationType.WEB, signatureCheckApp, bytes4(EMPTY), EMPTY);
 		doug.deployContract("AgreementSignatureCheck", signatureCheckApp);
-		if (signatureCheckApp.getBpmService() != address(bpmService)) return "$1";
+		if (signatureCheckApp.getBpmService() != address(bpmService)) return "BpmService not injected successfully into AgreementSignatureCheck application";
 
 		//
 		// ORGS/USERS
@@ -185,7 +185,7 @@ contract ActiveAgreementWorkflowTest {
 		org2 = new DefaultOrganization(approvers, EMPTY_STRING);
 		org1.addUserToDepartment(userAccount2, EMPTY);
 		org2.addDepartment(departmentId1, "Department 1");
-		org2.addUserToDepartment(userAccount3, departmentId1);
+		if (!org2.addUserToDepartment(userAccount3, departmentId1)) return "Failed to add user3 to department1";
 
 		delete parties;
 		// the parties to the agreement are: one user, one org, and one org with department scope
@@ -206,7 +206,7 @@ contract ActiveAgreementWorkflowTest {
 		if (addr == 0x0) return "Unable to create FormationProcess definition";
 		formationPD = ProcessDefinition(addr);
 		error = formationPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.USER, BpmModel.TaskBehavior.SENDRECEIVE, participantId1, true, appIdSignatureCheck, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating USER task for formation process definition";
 		formationPD.createDataMapping(activityId1, BpmModel.Direction.IN, "agreement", "agreement", EMPTY, 0x0);
 		(valid, errorMsg) = formationPD.validate();
 		if (!valid) return errorMsg.toString();
@@ -215,7 +215,7 @@ contract ActiveAgreementWorkflowTest {
 		if (addr == 0x0) return "Unable to create ExecutionProcess definition";
 		executionPD = ProcessDefinition(addr);
 		error = executionPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.SEND, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating SERVICE task for execution process definition";
 		(valid, errorMsg) = executionPD.validate();
 		if (!valid) return errorMsg.toString();
 
@@ -237,63 +237,67 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// FORMATION / EXECUTION
 		//
-		if (bpmService.getNumberOfProcessInstances() != 0) return "$1";
+		if (bpmService.getNumberOfProcessInstances() != 0) return "here should be 0 PIs in the system at test start";
 		(error, addr) = agreementRegistry.startFormation(ActiveAgreement(agreement));
 		if (error != BaseErrors.NO_ERROR()) return "Error starting the formation on agreement";
 		if (ActiveAgreement(agreement).getLegalState() != uint8(Agreements.LegalState.FORMULATED)) return "The agreement should be in FORMULATED state";
 
 		ProcessInstance pi;
-		if (bpmService.getNumberOfProcessInstances() != 1) return "$1";
+		if (bpmService.getNumberOfProcessInstances() != 1) return "There should be 1 PI in the system after agreement formation start";
 		if (bpmService.getBpmServiceDb().getNumberOfActivityInstances() != 3) return "There should be 3 AIs total";
 		pi = ProcessInstance(bpmService.getProcessInstanceAtIndex(0));
 		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The Formation PI should be active";
 		( , , , addr, , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
-		if (addr != address(userAccount1)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "Activity1 in Formation Process should be suspended";
+		if (addr != address(userAccount1)) return "userAccount1 should be the performer of activity1";
 
 		// the agreement should NOT be available as IN data via the application at this point since the user is still the performer!
 		if (address(signatureCheckApp).call(keccak256(abi.encodePacked("getInDataAgreement(bytes32)")), pi.getActivityInstanceAtIndex(0)))
-			return "$1";
+			return "Retrieving IN data via the application should REVERT while the user is still the performer";
 
 		// test fail on invalid user
 		error = nonPartyAccount.completeActivity(pi.getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.INVALID_ACTOR()) return "$1";
+		if (error != BaseErrors.INVALID_ACTOR()) return "Attempting to complete the Sign activity with an unassigned user should fail.";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "Activity1 in Formation Process should still be suspended after wrong user attempt";
 		// test fail on unsigned agreement
 		error = userAccount1.completeActivity(pi.getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.RUNTIME_ERROR()) return "$1";
+		if (error != BaseErrors.RUNTIME_ERROR()) return "Attempting to complete the Sign activity without signing the agreement should fail";
 		( , , , addr, , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
-		if (addr != address(userAccount1)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "Activity1 in Formation Process should still be suspended after completion attempt without signing";
+		if (addr != address(userAccount1)) return "userAccount1 should still be the performer of activity1 even after completion failed";
 
 		// test successful completion
 		userAccount1.signAgreement(agreement);
 		error = userAccount1.completeActivity(pi.getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error attempting to complete Activity1 in Formation Process by user1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "ActivityInstance 1 in Formation Process should be completed";
 
 		// verify that the signature app had access to the agreement data mapping
-		if (signatureCheckApp.lastAgreement() != address(agreement)) return "$1";
+		if (signatureCheckApp.lastAgreement() != address(agreement)) return "The agreement should've been processed by the TestSignatureCheck app.";
 
 		// complete the missing signatures and tasks
 		userAccount2.signAgreement(agreement);
 		error = userAccount2.completeActivity(pi.getActivityInstanceAtIndex(1), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error attempting to complete Activity1 in Formation Process by user2 in org1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "ActivityInstance 2 in Formation Process should be completed";
 
 		userAccount3.signAgreement(agreement);
 
-		if (pi.resolveAddressScope(address(org2), activityId1, pi) != departmentId1) return "$1";
+		( , , ,addr , , ) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(2));
+		if (addr != address(org2)) return "ActivityInstance3 should have org2 as performer";
+		if (pi.resolveAddressScope(address(org2), activityId1, pi) != departmentId1) return "Org2 in context of activity1 should show the additional department scope";
+		// check upfront if the user/org/department context is authorized which is used in the following completeActivity() invocation
+		if (!org2.authorizeUser(userAccount3, departmentId1)) return "User3 should be authorized for dep1 in org2";
 		error = userAccount3.completeActivity(pi.getActivityInstanceAtIndex(2), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return string(abi.encodePacked("Unexpected error attempting to complete Activity1 in Formation Process by user3 in org2: ",TypeUtilsAPI.toBytes32(error)));
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(2));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "ActivityInstance 3 in Formation Process should be completed";
 
 		// AIs 1-3 should all be completed now and the process has moved into execution
-		if (bpmService.getNumberOfProcessInstances() != 2) return "$1";
+		if (bpmService.getNumberOfProcessInstances() != 2) return "There should be 2 PIs in the system after agreement formation is completed";
 		if (bpmService.getBpmServiceDb().getNumberOfActivityInstances() != 4) return "There should be 4 AIs total";
 		pi = ProcessInstance(bpmService.getProcessInstanceAtIndex(1));
 		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The Execution PI should be completed";
@@ -341,7 +345,7 @@ contract ActiveAgreementWorkflowTest {
 		if (addr == 0x0) return "Unable to create FormationProcess definition";
 		formationPD = ProcessDefinition(addr);
 		error = formationPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.RECEIVE, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating NONE task for formation process definition";
 		(valid, errorMsg) = formationPD.validate();
 		if (!valid) return errorMsg.toString();
 		// Execution Process
@@ -349,7 +353,7 @@ contract ActiveAgreementWorkflowTest {
 		if (addr == 0x0) return "Unable to create ExecutionProcess definition";
 		executionPD = ProcessDefinition(addr);
 		error = executionPD.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.RECEIVE, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating SERVICE task for execution process definition";
 		(valid, errorMsg) = executionPD.validate();
 		if (!valid) return errorMsg.toString();
 
@@ -375,47 +379,47 @@ contract ActiveAgreementWorkflowTest {
 		numberOfPIs = bpmService.getNumberOfProcessInstances();
 		ProcessInstance[3] memory pis; // to collect the created PIs
 		(error, addr) = agreementRegistry.startFormation(ActiveAgreement(agreement1));
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error starting the formation process 1 on agreement1";
 		pis[0] = ProcessInstance(addr);
-		if (agreementRegistry.getTrackedFormationProcess(agreement1) == 0x0) return "$1";
-		if (agreementRegistry.getTrackedExecutionProcess(agreement1) != 0x0) return "$1";
-		if (agreementRegistry.getTrackedFormationProcess(agreement1) != address(pis[0])) return "$1";
+		if (agreementRegistry.getTrackedFormationProcess(agreement1) == 0x0) return "There should be a tracked formation process for agreement1";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement1) != 0x0) return "There should be NO tracked execution process for agreement1";
+		if (agreementRegistry.getTrackedFormationProcess(agreement1) != address(pis[0])) return "The tracked formation process should match the started formation PI for agreement1";
 		(error, addr) = agreementRegistry.startFormation(ActiveAgreement(agreement2));
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error starting the formation process 2 on agreement2";
 		pis[1] = ProcessInstance(addr);
-		if (agreementRegistry.getTrackedFormationProcess(agreement2) == 0x0) return "$1";
-		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != 0x0) return "$1";
-		if (agreementRegistry.getTrackedFormationProcess(agreement2) != address(pis[1])) return "$1";
+		if (agreementRegistry.getTrackedFormationProcess(agreement2) == 0x0) return "There should be a tracked formation process for agreement2";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != 0x0) return "There should be NO tracked execution process for agreement2";
+		if (agreementRegistry.getTrackedFormationProcess(agreement2) != address(pis[1])) return "The tracked formation process should match the started formation PI for agreement2";
 
 		// sign agreement2 and move PI2 into execution phase
 		userAccount1.signAgreement(agreement2);
 		userAccount2.signAgreement(agreement2);
-		if (ActiveAgreement(agreement2).getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "$1";
+		if (ActiveAgreement(agreement2).getLegalState() != uint8(Agreements.LegalState.EXECUTED)) return "The agreement2 should be in EXECUTED after signing";
 		error = pis[1].completeActivity(pis[1].getActivityInstanceAtIndex(0), bpmService);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error completing wait activity in formation process 2";
 	
-		if (bpmService.getNumberOfProcessInstances() != numberOfPIs+3) return "$1";
+		if (bpmService.getNumberOfProcessInstances() != numberOfPIs+3) return "There should be 3 additional PIs in the system";
 		numberOfPIs = bpmService.getNumberOfProcessInstances();
 		// the last added PI should be the execution process of agreement2
 		pis[2] = ProcessInstance(bpmService.getProcessInstanceAtIndex(numberOfPIs-1));
-		if (agreementRegistry.getTrackedExecutionProcess(agreement2) == 0x0) return "$1";
-		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != address(pis[2])) return "$1";
-		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
-		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "$1";
-		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement2) == 0x0) return "There should now be a tracked execution process for agreement2 after signing";
+		if (agreementRegistry.getTrackedExecutionProcess(agreement2) != address(pis[2])) return "The tracked execution process for agreement2 should match the last PI";
+		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The Formation PI for agreement1 should be active";
+		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The Formation PI for agreement2 should be completed";
+		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The Execution PI for agreement2 should be active";
 
 		// cancel the first agreement BEFORE its execution phase (uni-lateral cancellation)
 		userAccount2.cancelAgreement(agreement1);
 		if (ActiveAgreement(agreement1).getLegalState() != uint8(Agreements.LegalState.CANCELED)) return "agreement1 should be CANCELED";
-		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return "$1";
+		if (pis[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return "The Formation PI for agreement1 should be aborted after canceling";
 		
 		// cancel the second agreement AFTER it reaches execution phase (multi-lateral cancellation required)
 		userAccount2.cancelAgreement(agreement2);
-		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "$1";
-		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
+		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The Formation PI for agreement2 should still be completed after 1st cancellation";
+		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The Formation PI for agreement2 should still be active after 1st cancellation";
 		userAccount1.cancelAgreement(agreement2);
-		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "$1";
-		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return "$1";
+		if (pis[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The Formation PI for agreement2 should still be completed after 2nd cancellation";
+		if (pis[2].getState() != uint8(BpmRuntime.ProcessInstanceState.ABORTED)) return "The Formation PI for agreement2 should be aborted after 2nd cancellation";
 
 		return SUCCESS;
 	}

--- a/contracts/src/bpm-model/test/ProcessModelTest.sol
+++ b/contracts/src/bpm-model/test/ProcessModelTest.sol
@@ -35,38 +35,38 @@ contract ProcessModelTest {
 		if (secret != "hoardSecret") return "wrong hoard secret retrieved";
 
 		(error, newAddress) = pm.createProcessDefinition("p1");
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error creating ProcessDefinition p1";
 		ProcessDefinition pd = ProcessDefinition(newAddress);
 		
-		if (pm.getProcessDefinition("p1") != address(pd)) return "$1";
+		if (pm.getProcessDefinition("p1") != address(pd)) return "Returned ProcessDefinition address does not match.";
 
 		// test process interface handling
 		error = pm.addProcessInterface("AgreementFormation");
 		if (error != BaseErrors.NO_ERROR()) return "Unable to add process interface to model";
 		error = pd.addProcessInterfaceImplementation(0x0, "AgreementFormation");
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unable to add valid process interface to process definition.";
 		if (pm.getNumberOfProcessInterfaces() != 1) return "Wrong number of process interfaces";
 
 		// test participants
 		error = pm.addParticipant(participant1Id, 0x0, EMPTY, EMPTY, 0x0);
-		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "$1";
+		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "Expected INVALID_PARAM_VALUE setting conditional participant without dataPath";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, EMPTY, this);
-		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "$1";
+		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "Expected INVALID_PARAM_VALUE setting participant and conditional participant dataStorage";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, "storageId", 0x0);
-		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "$1";
+		if (error != BaseErrors.INVALID_PARAM_VALUE()) return "Expected INVALID_PARAM_VALUE setting participant and conditional participant dataStorage ID";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, EMPTY, 0x0);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding valid participant1 to the model";
 		error = pm.addParticipant(participant1Id, participant1Address, EMPTY, EMPTY, 0x0);
-		if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
+		if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "Expected RESOURCE_ALREADY_EXISTS adding participant twice";
 
 		error = pm.addParticipant(participant2Id, 0x0, "Buyer", "myDataStore", 0x0);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding valid participant2 to the model";
 		if (pm.getConditionalParticipant("Buyer", "", 0x0) != "")
-			return "$1";
+			return "Retrieving invalid conditional participant Buyer should return nothing";
 		if (pm.getConditionalParticipant("", "", 0x0) != "")
 			return "Retrieving empty conditional participant should return nothing";
 		if (pm.getConditionalParticipant("Buyer", "myDataStore", 0x0) != participant2Id)
-			return "$1";
+			return "Retrieving valid conditional participant should return participant2";
 
 		return "success";
 	}

--- a/contracts/src/bpm-runtime/BpmService.sol
+++ b/contracts/src/bpm-runtime/BpmService.sol
@@ -248,7 +248,7 @@ contract BpmService is Upgradeable {
 	 * @param _processInstance the address of a ProcessInstance
 	 * @return the number of scopes
 	 */
-	function getNumberOfAddressDataScopes(address _processInstance) external view returns (uint size);
+	function getNumberOfAddressScopes(address _processInstance) external view returns (uint size);
 
 	/**
 	 * @dev Returns the address scope key at the given index position of the specified ProcessInstance.

--- a/contracts/src/bpm-runtime/BpmService.sol
+++ b/contracts/src/bpm-runtime/BpmService.sol
@@ -165,14 +165,14 @@ contract BpmService is Upgradeable {
 	 * @dev Returns the number of Process Instances.
 	 * @return the process instance count as size
 	 */
-  function getNumberOfProcessInstances() external view returns (uint size);
+	function getNumberOfProcessInstances() external view returns (uint size);
 
 	/**
 	 * @dev Returns the process instance address at the specified index
 	 * @param _pos the index
 	 * @return the process instance address or or BaseErrors.INDEX_OUT_OF_BOUNDS(), 0x0
 	 */
-  function getProcessInstanceAtIndex(uint _pos) external view returns (address processInstanceAddress);
+	function getProcessInstanceAtIndex(uint _pos) external view returns (address processInstanceAddress);
 
 	/**
 	 * @dev Returns information about the process intance with the specified address
@@ -181,13 +181,13 @@ contract BpmService is Upgradeable {
 	 * @return state the BpmRuntime.ProcessInstanceState as uint8
 	 * @return startedBy the address of the account who started the process
 	 */
-  function getProcessInstanceData(address _address) external view returns (address processDefinition, uint8 state, address startedBy);
+	function getProcessInstanceData(address _address) external view returns (address processDefinition, uint8 state, address startedBy);
 
 	/**
-   * @dev Returns the number of activity instances.
-   * @return the activity instance count as size
-   */
-  function getNumberOfActivityInstances(address _address) external view returns (uint size);
+	 * @dev Returns the number of activity instances.
+	 * @return the activity instance count as size
+	 */
+	function getNumberOfActivityInstances(address _address) external view returns (uint size);
 
 	/**
 	 * @dev Returns the ActivityInstance ID at the specified index
@@ -195,20 +195,20 @@ contract BpmService is Upgradeable {
 	 * @param _pos the activity instance index
 	 * @return the ActivityInstance ID
 	 */
-  function getActivityInstanceAtIndex(address _address, uint _pos) external view returns (bytes32 activityId);
+	function getActivityInstanceAtIndex(address _address, uint _pos) external view returns (bytes32 activityId);
 
  	/**
-   * @dev Returns ActivityInstance data for the given ActivityInstance ID
-   * @param _processInstance the process instance address to which the ActivityInstance belongs
-   * @param _id the global ID of the activity instance
-   * @return activityId - the ID of the activity as defined by the process definition
-   * @return created - the creation timestamp
-   * @return completed - the completion timestamp
-   * @return performer - the account who is performing the activity (for interactive activities only)
-   * @return completedBy - the account who completed the activity (for interactive activities only) 
-   * @return state - the uint8 representation of the BpmRuntime.ActivityInstanceState of this activity instance
-   */
-  function getActivityInstanceData(address _processInstance, bytes32 _id) external view returns (
+ 	 * @dev Returns ActivityInstance data for the given ActivityInstance ID
+	 * @param _processInstance the process instance address to which the ActivityInstance belongs
+	 * @param _id the global ID of the activity instance
+	 * @return activityId - the ID of the activity as defined by the process definition
+	 * @return created - the creation timestamp
+	 * @return completed - the completion timestamp
+	 * @return performer - the account who is performing the activity (for interactive activities only)
+	 * @return completedBy - the account who completed the activity (for interactive activities only) 
+	 * @return state - the uint8 representation of the BpmRuntime.ActivityInstanceState of this activity instance
+	 */
+	function getActivityInstanceData(address _processInstance, bytes32 _id) external view returns (
         bytes32 activityId, 
         uint created,
         uint completed,
@@ -220,14 +220,14 @@ contract BpmService is Upgradeable {
 	 * @dev Returns the number of process data entries.
 	 * @return the process data size
 	 */
-  function getNumberOfProcessData(address _address) external view returns (uint size);
+	function getNumberOfProcessData(address _address) external view returns (uint size);
 
 	/**
 	 * @dev Returns the process data ID at the specified index
 	 * @param _pos the index
 	 * @return the data ID
 	 */
-  function getProcessDataAtIndex(address _address, uint _pos) external view returns (bytes32 dataId);
+	function getProcessDataAtIndex(address _address, uint _pos) external view returns (bytes32 dataId);
 
 	/**
 	 * @dev Returns information about the process data entry for the specified process and data ID
@@ -235,38 +235,74 @@ contract BpmService is Upgradeable {
 	 * @param _dataId the data ID
 	 * @return (process,id,uintValue,bytes32Value,addressValue,boolValue)
 	 */
-  function getProcessDataDetails(address _address, bytes32 _dataId) external view returns (
-		uint uintValue,
-		int intValue,
-		bytes32 bytes32Value,
-		address addressValue,
-		bool boolValue);
+	function getProcessDataDetails(address _address, bytes32 _dataId)
+		external view
+		returns (uint uintValue,
+				 int intValue,
+				 bytes32 bytes32Value,
+				 address addressValue,
+				 bool boolValue);
 
 	/**
-   * @dev Returns the address of the ProcessInstance of the specified ActivityInstance ID
-   * @param _aiId the ID of an ActivityInstance
-   * @return the ProcessInstance address or 0x0 if it cannot be found
-   */
-  function getProcessInstanceForActivity(bytes32 _aiId) external view returns (address);
+	 * @dev Returns the number of address scopes for the given ProcessInstance.
+	 * @param _processInstance the address of a ProcessInstance
+	 * @return the number of scopes
+	 */
+	function getNumberOfAddressDataScopes(address _processInstance) external view returns (uint size);
+
+	/**
+	 * @dev Returns the address scope key at the given index position of the specified ProcessInstance.
+	 * @param _processInstance the address of a ProcessInstance
+	 * @param _index the index position
+	 * @return the bytes32 scope key
+	 */
+	function getAddressScopeKeyAtIndex(address _processInstance, uint _index) external view returns (bytes32);
+
+	/**
+	 * @dev Returns detailed information about the address scope with the given key in the specified ProcessInstance
+	 * @param _processInstance the address of a ProcessInstance
+	 * @param _key a scope key
+	 * @return keyAddress - the address encoded in the key
+	 * @return keyContext - the context encoded in the key
+	 * @return fixedScope - a bytes32 representing a fixed scope
+	 * @return dataPath - the dataPath of a ConditionalData defining the scope
+	 * @return dataStorageId - the dataStorageId of a ConditionalData defining the scope
+	 * @return dataStorage - the dataStorgage address of a ConditionalData defining the scope
+	 */
+	function getAddressScopeDetails(address _processInstance, bytes32 _key)
+		external view
+		returns (address keyAddress,
+				 bytes32 keyContext,
+				 bytes32 fixedScope,
+				 bytes32 dataPath,
+				 bytes32 dataStorageId,
+				 address dataStorage);
+
+	/**
+	 * @dev Returns the address of the ProcessInstance of the specified ActivityInstance ID
+	 * @param _aiId the ID of an ActivityInstance
+	 * @return the ProcessInstance address or 0x0 if it cannot be found
+	 */
+	function getProcessInstanceForActivity(bytes32 _aiId) external view returns (address);
 
 	/**
 	 * @dev Returns a reference to the BpmServiceDb currently used by this BpmService
 	 * @return the BpmServiceDb
 	 */
-  function getBpmServiceDb() external view returns (BpmServiceDb);
+	function getBpmServiceDb() external view returns (BpmServiceDb);
 
 	/**
 	 * @dev Fires the UpdateActivities event to update sqlsol with given activity
 	 * @param _piAddress - the address of the process instance to which the activity belongs
 	 * @param _activityId - the bytes32 Id of the activity
 	 */
-  function fireActivityUpdateEvent(address _piAddress, bytes32 _activityId) external;
+	function fireActivityUpdateEvent(address _piAddress, bytes32 _activityId) external;
 
 	/**
-   * @dev Fires the UpdateProcessData event to update sqlsol with given information
-   * @param _piAddress - the address of the process instance to which the activity belongs
-   * @param _dataId - the ID of the data entry
-   */
-  function fireProcessDataUpdateEvent(address _piAddress, bytes32 _dataId) external;
+	 * @dev Fires the UpdateProcessData event to update sqlsol with given information
+	 * @param _piAddress - the address of the process instance to which the activity belongs
+	 * @param _dataId - the ID of the data entry
+	 */
+	function fireProcessDataUpdateEvent(address _piAddress, bytes32 _dataId) external;
 
 }

--- a/contracts/src/bpm-runtime/DefaultBpmService.sol
+++ b/contracts/src/bpm-runtime/DefaultBpmService.sol
@@ -444,9 +444,9 @@ contract DefaultBpmService is Versioned(1,0,0), AbstractDbUpgradeable, ContractL
     }
 
     /**
-    * @dev Returns the number of activity instances.
-    * @return the activity instance count as size
-    */
+     * @dev Returns the number of activity instances.
+     * @return the activity instance count as size
+     */
     function getNumberOfActivityInstances(address _address) external view returns (uint size) {
         return ProcessInstance(_address).getNumberOfActivityInstances();
     }
@@ -523,6 +523,48 @@ contract DefaultBpmService is Versioned(1,0,0), AbstractDbUpgradeable, ContractL
         bytes32Value = ProcessInstance(_address).getDataValueAsBytes32(_dataId);
         addressValue = ProcessInstance(_address).getDataValueAsAddress(_dataId);
         boolValue = ProcessInstance(_address).getDataValueAsBool(_dataId);
+    }
+
+	/**
+	 * @dev Returns the number of address scopes for the given ProcessInstance.
+	 * @param _processInstance the address of a ProcessInstance
+	 * @return the number of scopes
+	 */
+	function getNumberOfAddressDataScopes(address _processInstance) external view returns (uint size) {
+        size = ProcessInstance(_processInstance).getAddressScopeKeys().length;
+    }
+
+	/**
+	 * @dev Returns the address scope key at the given index position of the specified ProcessInstance.
+	 * @param _processInstance the address of a ProcessInstance
+	 * @param _index the index position
+	 * @return the bytes32 scope key
+	 */
+	function getAddressScopeKeyAtIndex(address _processInstance, uint _index) external view returns (bytes32) {
+        return ProcessInstance(_processInstance).getAddressScopeKeys()[_index];
+    }
+
+	/**
+	 * @dev Returns detailed information about the address scope with the given key in the specified ProcessInstance
+	 * @param _processInstance the address of a ProcessInstance
+	 * @param _key a scope key
+	 * @return keyAddress - the address encoded in the key
+	 * @return keyContext - the context encoded in the key
+	 * @return fixedScope - a bytes32 representing a fixed scope
+	 * @return dataPath - the dataPath of a ConditionalData defining the scope
+	 * @return dataStorageId - the dataStorageId of a ConditionalData defining the scope
+	 * @return dataStorage - the dataStorgage address of a ConditionalData defining the scope
+	 */
+	function getAddressScopeDetails(address _processInstance, bytes32 _key)
+		external view
+		returns (address keyAddress,
+				 bytes32 keyContext,
+				 bytes32 fixedScope,
+				 bytes32 dataPath,
+				 bytes32 dataStorageId,
+				 address dataStorage)
+    {
+        return ProcessInstance(_processInstance).getAddressScopeDetailsForKey(_key);
     }
 
     /**

--- a/contracts/src/bpm-runtime/DefaultBpmService.sol
+++ b/contracts/src/bpm-runtime/DefaultBpmService.sol
@@ -530,7 +530,7 @@ contract DefaultBpmService is Versioned(1,0,0), AbstractDbUpgradeable, ContractL
 	 * @param _processInstance the address of a ProcessInstance
 	 * @return the number of scopes
 	 */
-	function getNumberOfAddressDataScopes(address _processInstance) external view returns (uint size) {
+	function getNumberOfAddressScopes(address _processInstance) external view returns (uint size) {
         size = ProcessInstance(_processInstance).getAddressScopeKeys().length;
     }
 

--- a/contracts/src/bpm-runtime/test/ApplicationRegistryTest.sol
+++ b/contracts/src/bpm-runtime/test/ApplicationRegistryTest.sol
@@ -37,20 +37,20 @@ contract ApplicationRegistryTest {
 
         // add applications
         error = registry.addApplication(serviceApp1Id, BpmModel.ApplicationType.SERVICE, app1, bytes4(EMPTY), EMPTY);
-        if (error != BaseErrors.NO_ERROR()) return "$1";
+        if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding application1 to the registry";
         error = registry.addApplication(serviceApp1Id, BpmModel.ApplicationType.SERVICE, app1, bytes4(EMPTY), EMPTY);
-        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
+        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "Expected RESOURCE_ALREADY_EXISTS for adding an already existing application1";
         error = registry.addApplication(serviceApp2Id, BpmModel.ApplicationType.SERVICE, app2, customCompletionFunction, EMPTY);
-        if (error != BaseErrors.NO_ERROR()) return "$1";
+        if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding an application2 to the registry";
 
         if (registry.getNumberOfApplications() != 2) return "There should be 2 applications registered";
 
         error = registry.addAccessPoint(serviceApp1Id, app1AccessPoint1, DataTypes.BYTES32(), BpmModel.Direction.IN);
-        if (error != BaseErrors.NO_ERROR()) return "$1";
+        if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding access point app1InData to ServiceApp1";
         error = registry.addAccessPoint(serviceApp1Id, app1AccessPoint2, DataTypes.STRING(), BpmModel.Direction.OUT);
-        if (error != BaseErrors.NO_ERROR()) return "$1";
+        if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding access point app1OutData to ServiceApp1";
         error = registry.addAccessPoint(serviceApp1Id, app1AccessPoint1, DataTypes.UINT(), BpmModel.Direction.IN);
-        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "$1";
+        if (error != BaseErrors.RESOURCE_ALREADY_EXISTS()) return "Expected error when trying to add duplicate access point";
         
         if (registry.getNumberOfAccessPoints(serviceApp1Id) != 2) return "Wrong access point count for ServiceApp1";
 
@@ -58,8 +58,8 @@ contract ApplicationRegistryTest {
         BpmModel.Direction direction;
 
         (dataType, direction) = registry.getAccessPointData(serviceApp1Id, app1AccessPoint1);
-        if (dataType != DataTypes.BYTES32()) return "$1";
-        if (direction != BpmModel.Direction.IN) return "$1";
+        if (dataType != DataTypes.BYTES32()) return "Expected bytes32 dataType for access point app1AccessPoint1";
+        if (direction != BpmModel.Direction.IN) return "Expected direction IN for access point app1AccessPoint1";
 
         uint8 myType;
         address location;

--- a/contracts/src/bpm-runtime/test/BpmServiceTest.sol
+++ b/contracts/src/bpm-runtime/test/BpmServiceTest.sol
@@ -36,6 +36,8 @@ contract BpmServiceTest {
 	using BpmRuntimeLib for BpmRuntime.Transition;
 	using BpmRuntimeLib for ProcessDefinition;
 
+	string constant EMPTY_STRING = "";
+
 	// test data
 	bytes32 activityId1 = "activity1";
 	bytes32 activityId2 = "activity2";
@@ -906,7 +908,7 @@ contract BpmServiceTest {
 
 		WorkflowUserAccount proxy1 = new WorkflowUserAccount("user1", this, 0x0);
 		WorkflowUserAccount organizationUser = new WorkflowUserAccount("TomHanks", this, 0x0);
-		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray);
+		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray, EMPTY_STRING);
 		if (!org1.addUser(organizationUser)) return "Unable to add user account to organization";
 
 		// Register a typical WEB application with only a webform

--- a/contracts/src/bpm-runtime/test/BpmServiceTest.sol
+++ b/contracts/src/bpm-runtime/test/BpmServiceTest.sol
@@ -752,12 +752,12 @@ contract BpmServiceTest {
 
 		// Activity1 is configured as an asynchronous invocation in order to test the IN/OUT data mappings
 		error = pd.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.EVENT, BpmModel.TaskBehavior.SENDRECEIVE, EMPTY, false, serviceApp1Id, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating EVENT task activity1 definition";
 		pd.createDataMapping(activityId1, BpmModel.Direction.IN, eventApp.inDataIdAge(), "Age", "storage", 0x0);
 		pd.createDataMapping(activityId1, BpmModel.Direction.IN, eventApp.inDataIdGreeting(), "Message", EMPTY, 0x0);
 		pd.createDataMapping(activityId1, BpmModel.Direction.OUT, eventApp.outDataIdResult(), "Response", EMPTY, 0x0);
 		error = pd.createActivityDefinition(activityId2, BpmModel.ActivityType.TASK, BpmModel.TaskType.SERVICE, BpmModel.TaskBehavior.SEND, EMPTY, false, serviceApp2Id, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating SERVICE task activity2 definition";
 		pd.createTransition(activityId1, activityId2);
 		
 		// Validate to set the start activity and enable runtime configuration
@@ -777,44 +777,44 @@ contract BpmServiceTest {
 		// verify PI and AI state
 		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The PI should still be active";
 		( , , , addr, , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "$1";
-		if (addr != address(eventApp)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "Activity1 should be suspended due to async invocation";
+		if (addr != address(eventApp)) return "The event app should be the performer of activity1";
 
 		// test IN data retrieval
 		(addr, dataPath) = pi.resolveInDataLocation(pi.getActivityInstanceAtIndex(0), eventApp.inDataIdAge());
-		if (addr != address(dataStorage)) return "$1";
-		if (dataPath != "Age") return "$1";
+		if (addr != address(dataStorage)) return "The storage location for inDataIdAge should be the internal DataStorage";
+		if (dataPath != "Age") return "The dataPath after storage resolution for inDataIdAge is not correct";
 		(addr, dataPath) = pi.resolveInDataLocation(pi.getActivityInstanceAtIndex(0), eventApp.inDataIdGreeting());
-		if (addr != address(pi)) return "$1";
-		if (dataPath != "Message") return "$1";
+		if (addr != address(pi)) return "The storage location for inDataIdGreeting should be the ProcessInstance";
+		if (dataPath != "Message") return "The dataPath after storage resolution for inDataIdGreeting is not correct";
 
 		// test failure scenarios for IN mappings
 		if (address(service).call(keccak256(abi.encodePacked("getActivityInDataAsUint(bytes32,bytes32)")), eventApp.activityInstanceId(), eventApp.inDataIdAge()))
 			return "Retrieving IN data outside of the application should REVERT";
 		if (address(eventApp).call(keccak256(abi.encodePacked("retrieveInDataAge()"))))
-			return "$1";
+			return "Retrieving IN data in the event application outside of APPLICATION state should REVERT";
 		// test successful IN mappings set during completion of the event
 		if (eventApp.getAgeDuringCompletion() != 78)
-			return "$1";
+			return "IN data inDataIdAge not correctly saved during completion of eventApp";
 		if (keccak256(abi.encodePacked(eventApp.getGreetingDuringCompletion())) != keccak256(abi.encodePacked("Hello World")))
-			return "$1";
+			return "IN data inDataIdGreeting not correctly saved during completion of eventApp";
 
 		// trying to set OUT data from here should fail
 		if (address(service).call(keccak256(abi.encodePacked("setActivityOutDataAsBytes32(bytes32,bytes32,bytes32)")), eventApp.activityInstanceId(), eventApp.inDataIdAge(), "bla"))
 			return "Retrieving IN data outside of the application should REVERT";
 		// try completing activity1 from here should fail
 		error = pi.completeActivity(pi.getActivityInstanceAtIndex(0), service);
-		if (error != BaseErrors.INVALID_ACTOR()) return "$1";
+		if (error != BaseErrors.INVALID_ACTOR()) return "Only the application should be able to complete the suspended EVENT task";
 
 		error = eventApp.completeExternal(pi.getActivityInstanceAtIndex(0), "Hello back");
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error completing event task activity1 via the application";
 
 		// // verify out data correctly stored in process by the event app
 		if (pi.getDataValueAsBytes32("Response") != "Hello back")
-			return "$1";
+			return "OUT data outDataIdResult not correctly stored in process via eventApp";
 
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
-		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "$1";
+		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity1 should be completed after the external completion";
 		// activity2 should be interrupted at first
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.INTERRUPTED)) return "Activity2 should be interrupted";
@@ -823,7 +823,7 @@ contract BpmServiceTest {
 		serviceApp.reset();
 		// recovery should be possible from here and not via the service contract
 		error = pi.completeActivity(pi.getActivityInstanceAtIndex(1), service);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error trying to recover interrupted activityInstance";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity2 should be completed now";
 
@@ -866,7 +866,7 @@ contract BpmServiceTest {
 
 		// creating a valid model with a single activity
 		error = pd.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.SEND, EMPTY, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating USER task activity for participant1";
 		(valid, errorMsg) = pd.validate();
 		if (!valid) return errorMsg.toString();
 
@@ -877,17 +877,17 @@ contract BpmServiceTest {
 
 		bytes32 dataPath;
 		(addr, dataPath) = pi.resolveParticipant(participantId1);
-		if (addr != address(dataStorage)) return "$1";
-		if (dataPath != dataPathOnAgreement) return "$1";
+		if (addr != address(dataStorage)) return "DataStorage address not resolved correctly for participant1";
+		if (dataPath != dataPathOnAgreement) return "DataPath not resolved correctly for participant1";
 		(addr, dataPath) = pi.resolveParticipant(participantId2);
-		if (addr != address(this)) return "$1";
-		if (dataPath != "") return "$1";
+		if (addr != address(this)) return "Participant2 performer address should point to this contract.";
+		if (dataPath != "") return "DataPath should be empty for explicit participant2";
 		(addr, dataPath) = pi.resolveParticipant(participantId3);
-		if (addr != address(dataStorage)) return "$1";
-		if (dataPath != dataPathOnAgreement) return "$1";
+		if (addr != address(dataStorage)) return "DataStorage address not resolved correctly for participant3";
+		if (dataPath != dataPathOnAgreement) return "DataPath not resolved correctly for participant3";
 		(addr, dataPath) = pi.resolveParticipant(participantId4);
-		if (addr != address(pi)) return "$1";
-		if (dataPath != dataPathOnProcess) return "$1";
+		if (addr != address(pi)) return "Participant4 dataStorage should point to the ProcessInstance.";
+		if (dataPath != dataPathOnProcess) return "DataPath for participant4 not resolved correctly";
 
 		return SUCCESS;
 	}
@@ -906,6 +906,8 @@ contract BpmServiceTest {
 
 		TestBpmService service = getNewTestBpmService();
 
+		//TODO missing test coverage of the authorizePerformer function / completeActivity for users in different department settings
+
 		WorkflowUserAccount proxy1 = new WorkflowUserAccount("user1", this, 0x0);
 		WorkflowUserAccount organizationUser = new WorkflowUserAccount("TomHanks", this, 0x0);
 		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray, EMPTY_STRING);
@@ -913,7 +915,7 @@ contract BpmServiceTest {
 
 		// Register a typical WEB application with only a webform
 		error = applicationRegistry.addApplication("Webform1", BpmModel.ApplicationType.WEB, 0x0, bytes4(EMPTY), "MyCustomWebform");
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error registering WEB application for user task";
 
 		(error, addr) = repository.createProcessModel("testModelUserTasks", "UserTask Test Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
@@ -930,9 +932,9 @@ contract BpmServiceTest {
 		// Activity 1 is assigned to proxy1
 		// Activity 2 is assigned to the organizationUser via the org1 organization
 		error = pd.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.USER, BpmModel.TaskBehavior.SENDRECEIVE, participantId1, false, "Webform1", EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating USER task activity for participant1";
 		error = pd.createActivityDefinition(activityId2, BpmModel.ActivityType.TASK, BpmModel.TaskType.USER, BpmModel.TaskBehavior.SENDRECEIVE, participantId2, false, "Webform1", EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating USER task activity for participant2";
 		pd.createTransition(activityId1, activityId2);
 
 		pd.createDataMapping(activityId1, BpmModel.Direction.IN, "nameAccessPoint", "Name", "storage", 0x0);
@@ -951,12 +953,12 @@ contract BpmServiceTest {
 		if (address(service).call(bytes4(keccak256(abi.encodePacked("startProcessFromRepository(bytes32,bytes32,bytes32)"))), "FakeModelIdddddd", "UserTaskProcess", EMPTY))
 			return "Starting a process with invalid model ID should REVERT";
 		if (address(service).call(bytes4(keccak256(abi.encodePacked("startProcessFromRepository(bytes32,bytes32,bytes32)"))), pm.getId(), "TotallyFakeProcessssId", EMPTY))
-			return "$1";
+			return "Starting a process with invalid process definition ID should REVERT";
 
 		// test successful creation via model and pd IDs
 		(error, addr) = service.startProcessFromRepository(pm.getId(), "UserTaskProcess", EMPTY);
 		if (error != BaseErrors.NO_ERROR()) return "Unexpected error during process start";
-		if (addr == 0x0) return "$1";
+		if (addr == 0x0) return "No error during process start, but PI address is empty!";
 		ProcessInstance pi = ProcessInstance(addr);
 
 		// some of the data mappings reference a DataStorage object that needs to be set in the PI
@@ -965,7 +967,7 @@ contract BpmServiceTest {
 		// verify DB state
 		if (service.getNumberOfProcessInstances() != 1) return "There should be 1 PI after process start";
 		if (service.getNumberOfActivityInstances(pi) != 1) return "There should be 1 AI after process start";
-		if (pi.getNumberOfActivityInstances() != 1) return "$1";
+		if (pi.getNumberOfActivityInstances() != 1) return "There should be 1 AI in the ProcessInstance after start";
 
 		// verify individual activity instances
 		uint8 state;
@@ -975,48 +977,48 @@ contract BpmServiceTest {
 
 		// test data mappings via user-assigned task
 		if (address(service).call(bytes4(keccak256(abi.encodePacked("getActivityInDataAsBytes32(bytes32,bytes32)"))), pi.getActivityInstanceAtIndex(0), "nameAccessPoint"))
-			 return "$1";
+			 return "It should not be possible to access IN data mappings from a non-performer address";
 		if (proxy1.getActivityInDataAsBytes32(pi.getActivityInstanceAtIndex(0), "nameAccessPoint", service) != "Smith")
 			return "IN data mapping Name should return correctly via user proxy1";
 		proxy1.setActivityOutDataAsBool(pi.getActivityInstanceAtIndex(0), "approvedAccessPoint", true, service);
 
 		// complete user task 1 and check outcome
 		error = organizationUser.completeActivity(pi.getActivityInstanceAtIndex(0), service);
-		if (error != BaseErrors.INVALID_ACTOR()) return "$1";
+		if (error != BaseErrors.INVALID_ACTOR()) return "Expected error for organization user attempting to complete activity1";
 		error = proxy1.completeActivity(pi.getActivityInstanceAtIndex(0), service);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error attempting to complete activity1 user task via assigned proxy1 in activity1";
 		( , , , , addr, state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity1 should be completed";
 		if (addr != address(proxy1)) return "Activity1 should be completedBy proxy1";
 
 		// verify new world state
 		if (service.getNumberOfActivityInstances(pi) != 2) return "There should be 2 AIs after task1 completion";
-		if (pi.getNumberOfActivityInstances() != 2) return "$1";
+		if (pi.getNumberOfActivityInstances() != 2) return "There should be 2 AIs in the ProcessInstance after task1 completion";
 		( , , , addr, , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "Activity2 should be suspended";
-		if (addr != address(org1)) return "$1";
+		if (addr != address(org1)) return "Activity2 should be assigned to the organization org1";
 
 		// test data mappings via organization-assigned task
 		if (address(proxy1).call(bytes4(keccak256(abi.encodePacked("getActivityInDataAsBool(bytes32,bytes32)"))), pi.getActivityInstanceAtIndex(1), "approvedAccessPoint"))
-			return "$1";
+			return "It should not be possible to access IN data mappings from a user account that is not the performer";
 		if (organizationUser.getActivityInDataAsBool(pi.getActivityInstanceAtIndex(1), "approvedAccessPoint", service) != true)
-			return "$1";
+			return "IN data mapping Approved should return true via user organizationUser in activity2";
 		organizationUser.setActivityOutDataAsUint(pi.getActivityInstanceAtIndex(1), "ageAccessPoint", 21, service);
 
 		// complete user task 2 and check outcome
 		error = proxy1.completeActivity(pi.getActivityInstanceAtIndex(1), service);
-		if (error != BaseErrors.INVALID_ACTOR()) return "$1";
+		if (error != BaseErrors.INVALID_ACTOR()) return "Expected error for proxy1 account attempting to complete activity2";
 		// complete the activity here using an OUT data mapping to set the Age
 		error = organizationUser.completeActivityWithUintData(pi.getActivityInstanceAtIndex(1), service, "Age", 21);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error attempting to complete activity2 user task via organizationUser";
 		( , , , , addr, state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity2 should be completed";
-		if (addr != address(organizationUser)) return "$1";
+		if (addr != address(organizationUser)) return "Activity2 should be completedBy the organizationUser";
 		// check the fields that were set in the PI and data storage
 		if (pi.getDataValueAsBool("Approved") != true)
-			return "$1";
+			return "The Approved field in the PI should've been set via data mappings";
 		if (dataStorage.getDataValueAsUint("Age") != 21)
-			return "$1";
+			return "The Age field in the DataStorge should've been set at AI completion";
 
 		// verify process state
 		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The PI should be completed";
@@ -1055,7 +1057,7 @@ contract BpmServiceTest {
 		error = pd.createActivityDefinition(activityId1, BpmModel.ActivityType.TASK, BpmModel.TaskType.NONE, BpmModel.TaskBehavior.SEND, EMPTY, false, EMPTY, EMPTY, EMPTY);
 		if (error != BaseErrors.NO_ERROR()) return "Error creating NONE task activity";
 		error = pd.createActivityDefinition(activityId2, BpmModel.ActivityType.TASK, BpmModel.TaskType.USER, BpmModel.TaskBehavior.SENDRECEIVE, participantId1, false, EMPTY, EMPTY, EMPTY);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Error creating USER task activity for participant1";
 		pd.createTransition(activityId1, activityId2);
 		
 		// Validate to set the start activity and enable runtime configuration
@@ -1066,7 +1068,7 @@ contract BpmServiceTest {
 		// to make sure they are both abortable by the ower (this contract)
 		(error, addr) = service.startProcess(pd, EMPTY);
 		if (error != BaseErrors.NO_ERROR()) return "Unexpected error during process start";
-		if (addr == 0x0) return "$1";
+		if (addr == 0x0) return "No error during process start, but PI address is empty!";
 		ProcessInstance pi1 = ProcessInstance(addr);
 		ProcessInstance pi2 = new DefaultProcessInstance(pd, 0x0, EMPTY);
 		service.startProcessInstance(pi2);
@@ -1171,7 +1173,7 @@ contract BpmServiceTest {
 
 		// complete first user task
 		error = proxy1.completeActivity(pi.getActivityInstanceAtIndex(0), service);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error attempting to complete activity1.1 user task via proxy1";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(0));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity1.1 should be completed";
 
@@ -1179,15 +1181,15 @@ contract BpmServiceTest {
 		if (pi.getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The PI should be completed";
 
 		// number of AIs should still be 2 at this point
-		if (service.getNumberOfActivityInstances(pi) != 2) return "$1";
+		if (service.getNumberOfActivityInstances(pi) != 2) return "There should still be 2 AIs after completing only 1 instance";
 
 		// complete remaining user task
 		error = proxy2.completeActivity(pi.getActivityInstanceAtIndex(1), service);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error attempting to complete activity1.2 user task via proxy2";
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity1.2 should be completed";
 
-		if (service.getNumberOfActivityInstances(pi) != 3) return "$1";
+		if (service.getNumberOfActivityInstances(pi) != 3) return "There should be 3 AIs after completing all instances of the multi-instance user task";
 
 		// remaining activities should be completed
 		( , , , , , state) = pi.getActivityInstanceData(pi.getActivityInstanceAtIndex(1));
@@ -1235,7 +1237,7 @@ contract BpmServiceTest {
 		if (addr == 0x0) return "Unable to create SubProcessA ProcessDefinition";
 		ProcessDefinition pdSubA = ProcessDefinition(addr);
 		(error, addr) = pmA.createProcessDefinition("SubProcessA2");
-		if (addr == 0x0) return "$1";
+		if (addr == 0x0) return "Unable to create SubProcessA2 ProcessDefinition";
 		ProcessDefinition pdSubA2 = ProcessDefinition(addr);
 		(error, addr) = pmB.createProcessDefinition("SubProcessB");
 		if (addr == 0x0) return "Unable to create SubProcessB ProcessDefinition";
@@ -1276,7 +1278,7 @@ contract BpmServiceTest {
 	
 		// all processes should be active after main start
 		if (piMain.getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "The Main PI should be active";
-		if (piMain.getNumberOfActivityInstances() != 2) return "$1";
+		if (piMain.getNumberOfActivityInstances() != 2) return "There should be 2 AIs in the main process after start";
 		if (subProcesses[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "SubprocessA should be active";
 		if (subProcesses[1].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "SubprocessB should be active";
 		uint state;
@@ -1286,19 +1288,19 @@ contract BpmServiceTest {
 		if (state != uint8(BpmRuntime.ActivityInstanceState.SUSPENDED)) return "Activity2 in Main should be suspended";
 
 		// verify that data was propagated to the subprocess
-		if (subProcesses[0].getDataValueAsAddress("agreement") != address(this)) return "$1";
-		if (subProcesses[1].getDataValueAsAddress("agreement") != address(this)) return "$1";
+		if (subProcesses[0].getDataValueAsAddress("agreement") != address(this)) return "SubprocessA should have the agreement reference set";
+		if (subProcesses[1].getDataValueAsAddress("agreement") != address(this)) return "SubprocessB should have the agreement reference set";
 
 		// completing the SubprocessB activity should trigger completion of the subprocess and creation of the third subprocess
 		error = subProcesses[1].completeActivity(subProcesses[1].getActivityInstanceAtIndex(0), service);
-		if (error != BaseErrors.NO_ERROR()) return "$1";
+		if (error != BaseErrors.NO_ERROR()) return "Unexpected error completing the wait activity in SubprocessB";
 		( , , , , , state) = subProcesses[1].getActivityInstanceData(subProcesses[1].getActivityInstanceAtIndex(0));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity1 in SubprocessB should be completed";
 		( , , , , , state) = piMain.getActivityInstanceData(piMain.getActivityInstanceAtIndex(1));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity2 in Main should be completed now";
 		// after completing SubprocessB, the third subprocess A2 is synchronous and has no wait activity, so its completion should complete the main process
-		if (piMain.getNumberOfActivityInstances() != 3) return "$1";
-		if (service.getNumberOfProcessInstances() != 4) return "$1";
+		if (piMain.getNumberOfActivityInstances() != 3) return "There should be 3 AIs in the main process after completing SubprocessB";
+		if (service.getNumberOfProcessInstances() != 4) return "There should be 4 PIs after completing the SubprocessB";
 		( , , , , , state) = piMain.getActivityInstanceData(piMain.getActivityInstanceAtIndex(2));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity3 in Main should be completed";
 		subProcesses[2] = ProcessInstance(service.getProcessInstanceAtIndex(3));
@@ -1307,7 +1309,7 @@ contract BpmServiceTest {
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity2 in Main should be completed";
 		( , , , , , state) = piMain.getActivityInstanceData(piMain.getActivityInstanceAtIndex(2));
 		if (state != uint8(BpmRuntime.ActivityInstanceState.COMPLETED)) return "Activity2 in Main should be completed";
-		if (subProcesses[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "$1";
+		if (subProcesses[0].getState() != uint8(BpmRuntime.ProcessInstanceState.ACTIVE)) return "Aynchronous SubprocessA should still be active";
 		if (subProcesses[1].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "SubprocessB should be completed";		
 		if (subProcesses[2].getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "SubprocessA2 should be completed";		
 		if (piMain.getState() != uint8(BpmRuntime.ProcessInstanceState.COMPLETED)) return "The Main PI should be completed";

--- a/contracts/src/bpm-runtime/test/BpmServiceTest.sol
+++ b/contracts/src/bpm-runtime/test/BpmServiceTest.sol
@@ -909,7 +909,7 @@ contract BpmServiceTest {
 		WorkflowUserAccount proxy1 = new WorkflowUserAccount("user1", this, 0x0);
 		WorkflowUserAccount organizationUser = new WorkflowUserAccount("TomHanks", this, 0x0);
 		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray, EMPTY_STRING);
-		if (!org1.addUser(organizationUser)) return "Unable to add user account to organization";
+		if (!org1.addUserToDepartment(organizationUser, EMPTY)) return "Unable to add user account to organization default department";
 
 		// Register a typical WEB application with only a webform
 		error = applicationRegistry.addApplication("Webform1", BpmModel.ApplicationType.WEB, 0x0, bytes4(EMPTY), "MyCustomWebform");

--- a/contracts/src/bpm-runtime/test/ServiceUpgradeabilityTest.sol
+++ b/contracts/src/bpm-runtime/test/ServiceUpgradeabilityTest.sol
@@ -34,15 +34,15 @@ contract ServiceUpgradeabilityTest {
 			TestApplication app2 = new TestApplication();
 
 			error = registryV1.addApplication(serviceApp1Id, BpmModel.ApplicationType.SERVICE, app1, bytes4(EMPTY), EMPTY);
-			if (error != BaseErrors.NO_ERROR()) return "$1";
+			if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding application1 to registryV1";
 			error = registryV1.addApplication(serviceApp2Id, BpmModel.ApplicationType.SERVICE, app2, customCompletionFunction, EMPTY);
-			if (error != BaseErrors.NO_ERROR()) return "$1";
-			if (registryV1.getNumberOfApplications() != 2) return "$1";
+			if (error != BaseErrors.NO_ERROR()) return "Unexpected error adding application2 to registryV1";
+			if (registryV1.getNumberOfApplications() != 2) return "There should be 2 applications registered via registryV1";
 
 			ApplicationRegistry registryV2 = new  DefaultApplicationRegistry();
-			if (!AbstractDbUpgradeable(registryV1).migrateTo(registryV2)) return "$1";
-			if (registryV2.getNumberOfApplications() != 2) return "$1";
-			if (registryDb.getSystemOwner() != address(registryV2)) return "$1";
+			if (!AbstractDbUpgradeable(registryV1).migrateTo(registryV2)) return "Unexpected error while migrating from registryV1 to registryV2";
+			if (registryV2.getNumberOfApplications() != 2) return "There should be 2 applications registered via registryV2";
+			if (registryDb.getSystemOwner() != address(registryV2)) return "ApplicationRegistryDb owner is not set to registryV2";
 
 			return SUCCESS;
 	}

--- a/contracts/src/commons-auth/DefaultOrganization.sol
+++ b/contracts/src/commons-auth/DefaultOrganization.sol
@@ -230,7 +230,7 @@ contract DefaultOrganization is Organization, DefaultEventEmitter, AbstractERC16
 	 * @return true if authorized, false otherwise
 	 */
 	function authorizeUser(address _userAccount, bytes32 _department) external view returns (bool) {
-		if (_department != "" &&_department == keccak256(abi.encodePacked(address(this)))) {
+		if (_department == keccak256(abi.encodePacked(address(this)))) {
 			return users.exists(_userAccount);
 		}
 		else if (_department == "" || !self.departments[_department].exists) {

--- a/contracts/src/commons-auth/DefaultParticipantsManager.sol
+++ b/contracts/src/commons-auth/DefaultParticipantsManager.sol
@@ -102,11 +102,12 @@ contract DefaultParticipantsManager is Versioned(1,0,0), AbstractEventListener, 
 	/**
 	 * @dev Creates and adds a new Organization with the specified parameters
 	 * @param _approvers the initial owners. If left empty, the msg.sender will be added as an owner.
+	 * @param _defaultDepartmentName an optional custom name/label for the default department of this organization.
 	 * @return BaseErrors.NO_ERROR() if successful
 	 * @return the address of the newly created Organization, or 0x0 if not successful
 	 */
-    function createOrganization(address[10] _approvers) external returns (uint error, address organization) {
-        organization = new DefaultOrganization(_approvers);
+    function createOrganization(address[10] _approvers, string _defaultDepartmentName) external returns (uint error, address organization) {
+        organization = new DefaultOrganization(_approvers, _defaultDepartmentName);
         error = ParticipantsManagerDb(database).addOrganization(organization);
         if (error == BaseErrors.NO_ERROR()) {
             Organization(organization).addEventListener(EVENT_UPDATE_ORGANIZATION_USER);

--- a/contracts/src/commons-auth/Organization.sol
+++ b/contracts/src/commons-auth/Organization.sol
@@ -6,6 +6,7 @@ import "commons-events/EventEmitter.sol";
 /**
  * @title Organization Interface
  * @dev Describes functionality of a contract representing an organization in an ecosystem application.
+ * Also provides access to constants required when dealing with organizations.
  */
 contract Organization is EventEmitter, ERC165 {
 
@@ -13,8 +14,10 @@ contract Organization is EventEmitter, ERC165 {
 	bytes4 public constant ERC165_ID_Organization = bytes4(keccak256(abi.encodePacked("addUser(address)"))) ^
 													bytes4(keccak256(abi.encodePacked("removeUser(address)"))) ^
 													bytes4(keccak256(abi.encodePacked("authorizeUser(address,bytes32)")));
+
+	bytes32 public constant DEFAULT_DEPARTMENT_ID = "DEFAULT_DEPARTMENT";
 	
-	function addDepartment(bytes32 _id, string _name) external returns (uint error);
+	function addDepartment(bytes32 _id, string _name) public returns (uint error);
 
 	function getNumberOfDepartments() external view returns (uint size);
 

--- a/contracts/src/commons-auth/ParticipantsManager.sol
+++ b/contracts/src/commons-auth/ParticipantsManager.sol
@@ -46,9 +46,10 @@ contract ParticipantsManager is EventListener, Upgradeable {
 	/**
 	 * @dev Creates and adds a new Organization with the specified parameters
 	 * @param _approvers the initial owners.
+	 * @param _defaultDepartmentName an optional custom name/label for the default department of this organization.
 	 * @return error code and the address of the newly created organization, if successful
 	 */
-    function createOrganization(address[10] _approvers) external returns (uint, address);
+    function createOrganization(address[10] _approvers, string _defaultDepartmentName) external returns (uint, address);
 
 	/**
 		* @dev Indicates whether the specified organization exists for the given organization id

--- a/contracts/src/commons-standards/test/ERC165Test.sol
+++ b/contracts/src/commons-standards/test/ERC165Test.sol
@@ -15,9 +15,9 @@ contract ERC165Test {
 
         // fail
         if (myImplAddress.call(bytes4(keccak256(abi.encodePacked("addIllegalSupport()")))))
-            return "$1";
+            return "Custom contract should throw when adding illegal 0xffffffff interface";
         if (ERC165Utils.implementsInterface(myImplAddress, bytes4(keccak256(abi.encodePacked("unknownFunction(bytes32)")))) == true)
-            return "$1";
+            return "Custom contract should not support an unknown interface";
 
         // success
         if (ERC165Utils.implementsInterface(myImplAddress, 0x01ffc9a7) == false)

--- a/contracts/src/test-agreements.yaml
+++ b/contracts/src/test-agreements.yaml
@@ -49,6 +49,7 @@ jobs:
     instance: IsoCountries100
     libraries: ErrorsLib:$ErrorsLib
 
+
 # ArchetypeRegistryTest
 - name: ArchetypeRegistryTest
   deploy:
@@ -122,6 +123,7 @@ jobs:
     key: $testGoverningArchetypes
     relation: eq
     val: success
+
 
 # ActiveAgreementTest
 - name: ActiveAgreementTest

--- a/contracts/src/test-commons-auth.yaml
+++ b/contracts/src/test-commons-auth.yaml
@@ -18,6 +18,7 @@ jobs:
     contract: MappingsLib.bin
     libraries: TypeUtilsAPI:$TypeUtilsAPI, ArrayUtilsAPI:$ArrayUtilsAPI
 
+
 ##########
 # SecureNativeAuthorizations Tests
 
@@ -126,6 +127,7 @@ jobs:
 #     relation: eq
 #     val: success
 
+
 ##########
 # ParticipantsManager Tests
 
@@ -208,41 +210,18 @@ jobs:
     relation: eq
     val: success
 
-##########
-# Organization Creation Tests
+- name: testOrganizationAuthorization
+  call:
+    destination: $ParticipantsManagerTest
+    bin: ParticipantsManagerTest
+    function: testOrganizationAuthorization
 
-- name: Organization1
-  deploy:
-    contract: DefaultOrganization.bin
-    instance: DefaultOrganization
-    libraries: MappingsLib:$MappingsLib
-    data:
-      - [$defaultAddr, "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000"]
-
-- name: organization1ApproversSize
-  query-contract:
-    destination: $Organization1
-    bin: DefaultOrganization
-    function: getNumberOfApprovers
-
-- name: assertOrganization1ApproversSize
+- name: assertOrganizationAuthorization
   assert:
-    key: $organization1ApproversSize
+    key: $testOrganizationAuthorization
     relation: eq
-    val: 1
+    val: success
 
-- name: organization1Approver1
-  query-contract:
-    destination: $Organization1
-    bin: DefaultOrganization
-    function: getApproverAtIndex
-    data: [0]
-
-- name: assertOrganization1Approver1d
-  assert:
-    key: $organization1Approver1
-    relation: eq
-    val: $defaultAddr
 
 ##########
 # Ecosystem Tests


### PR DESCRIPTION
This PR completes AN-553, AN-554, AN-555.
A default department is now added to each organization automatically which serves as a catch-all for "unassigned" tasks, for example. The organization-level authorization has been refactored and is now represented by using a department scope that is the hash (keccak256) of the organization's address.
The agreement's sign() and cancel() functions now correctly respect department scope as well by using a scope set to the the reserved AGREEMENT_PARTIES constant.
The address scopes of process instances are now exposed in SQLsol in a new table PROCESS_INSTANCE_ADDRESS_SCOPES.
Lastly, this PR fixes the error string returns of multiple test contracts that were lost in a prior commit. 