### PR TITLE
Fix exception when using PROCESS_INSTANCE fields for transition conditions

### DIFF
--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -936,9 +936,9 @@ const getTransitionConditionFunctionByDataType = (processAddress, dataType) => {
 };
 
 const createTransitionCondition = (processAddress, dataType, gatewayId, activityId, dataPath, dataStorageId, dataStorage, operator, value) => new Promise((resolve, reject) => {
-  log.trace(`Creating transition condition with data: ${JSON.stringify({
+  log.debug('Creating transition condition with data: %s', JSON.stringify({
     processAddress, dataType, gatewayId, activityId, dataPath, dataStorageId, dataStorage, operator, value,
-  })}`);
+  }));
   const createFunction = getTransitionConditionFunctionByDataType(processAddress, dataType);
   createFunction(gatewayId, activityId, dataPath, dataStorageId, dataStorage, operator, value, (error) => {
     if (error) {

--- a/api/lib/bpmn-parser.js
+++ b/api/lib/bpmn-parser.js
@@ -260,11 +260,14 @@ const getTransitionFromNode = (node) => {
       throw boom.badData(`Invalid expression for transition ${node.id}. ` +
         '"lhDataPath", "lhDataStorageId", "operator" and "rhValue" are required fields.'); // TODO instead of rhValue (fixed), an rhDataStorageId and rhDataPath are also valid. The if statement needs work to support this
     }
-    // replace reserved DataStorage ID for PROCESS_INSTANCE with an empty string
-    properties.lhDataStorageId = properties.lhDataStorageId === BPMN_DATASTORAGEID_PROCESS_INSTANCE ? '' : properties.lhDataStorageId;
-    properties.rhDataStorageId = properties.rhDataStorageId === BPMN_DATASTORAGEID_PROCESS_INSTANCE ? '' : properties.rhDataStorageId;
+    // check if dataStorageIds are set and replace reserved DataStorage ID for PROCESS_INSTANCE with an empty string, if detected
+    if (properties.lhDataStorageId === BPMN_DATASTORAGEID_PROCESS_INSTANCE) {
+      properties.lhDataStorageId = '';
+    }
+    if (properties.rhDataStorageId === BPMN_DATASTORAGEID_PROCESS_INSTANCE) {
+      properties.rhDataStorageId = '';
+    }
     transition.condition = properties;
-
   }
   return transition;
 };

--- a/api/lib/bpmn-parser.js
+++ b/api/lib/bpmn-parser.js
@@ -258,9 +258,13 @@ const getTransitionFromNode = (node) => {
       properties.rhValue === undefined
     ) {
       throw boom.badData(`Invalid expression for transition ${node.id}. ` +
-        '"lhDataPath", "lhDataStorageId", "operator" and "rhValue" are required fields.');
+        '"lhDataPath", "lhDataStorageId", "operator" and "rhValue" are required fields.'); // TODO instead of rhValue (fixed), an rhDataStorageId and rhDataPath are also valid. The if statement needs work to support this
     }
+    // replace reserved DataStorage ID for PROCESS_INSTANCE with an empty string
+    properties.lhDataStorageId = properties.lhDataStorageId === BPMN_DATASTORAGEID_PROCESS_INSTANCE ? '' : properties.lhDataStorageId;
+    properties.rhDataStorageId = properties.rhDataStorageId === BPMN_DATASTORAGEID_PROCESS_INSTANCE ? '' : properties.rhDataStorageId;
     transition.condition = properties;
+
   }
   return transition;
 };

--- a/contracts/src/bpm-model/BpmModelLib.sol
+++ b/contracts/src/bpm-model/BpmModelLib.sol
@@ -13,6 +13,8 @@ import "bpm-model/BpmModel.sol";
  */
 library BpmModelLib {
 
+    using DataStorageUtils for DataStorageUtils.ConditionalData;
+
     /**
      * @dev Ensures that either an rhPrimitive or an rhData exists in the condition.
      * This modifier prevents accidentally working with a default return value for comparisons.
@@ -30,7 +32,7 @@ library BpmModelLib {
      * @return true if the condition evaluated to true, false otherwise
      */
     function resolve(BpmModel.TransitionCondition storage _condition, address _dataStorage) public view returns (bool) {
-        (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.lhData, _dataStorage);
+        (address dataStorage, bytes32 dataPath) = _condition.lhData.resolveDataLocation(DataStorage(_dataStorage));
         // the left-hand side of the expression determines the data type being used to compare
         uint8 dataType = DataStorage(dataStorage).getDataType(dataPath);
         if (dataType == DataTypes.BOOL()) {
@@ -54,34 +56,6 @@ library BpmModelLib {
     }
 
     /**
-     * @dev Returns the resolved location of the data specified by the data mapping for the specified ActivityInstance.
-     * REVERTS if:
-     * - the provided ConditionalData cannot be resolved to a DataStorage address
-     * @param _conditionalData the DataStorageUtils.ConditionalData to resolve
-     * @param _dataStorage a DataStorage address to use for resolving any ID references
-     * @return dataStorage - the address of a DataStorage that contains the requested data. Default is the ProcessInstance itself, if none other specified
-     * @return dataPath - the ID with which the data can be retrieved
-     */
-    function resolveConditionalDataLocation(DataStorageUtils.ConditionalData storage _conditionalData, address _dataStorage) public view returns (address dataStorage, bytes32 dataPath) {
-        dataPath = _conditionalData.dataPath;
-        if (_conditionalData.dataStorage != 0x0) {
-            dataStorage = _conditionalData.dataStorage;
-            return;
-        }
-        // at this point we need to rely on the second parameter _dataStorage
-        ErrorsLib.revertIf(_dataStorage == 0x0,
-            ErrorsLib.INVALID_STATE(), "BpmModelLib.resolveConditionalDataLocation", "Unable to determine a DataStorage address based on the provided parameters");
-        if (_conditionalData.dataStorageId != "") {
-            // retrieve the target by looking for the dataStorageId in the context of the provided dataStorage
-            dataStorage = DataStorage(_dataStorage).getDataValueAsAddress(_conditionalData.dataStorageId);
-        }
-        else {
-            // if no dataStorage location is configured, the provided dataStorage is used
-            dataStorage = _dataStorage;
-        }
-    }
-
-    /**
      * @dev Resolves the given TransitionCondition value as a bool using the provided DataStorage.
      * REVERTS: if the given condition does not have a right-hand side value (conditional or primitive)
      * @param _condition a BpmModel.TransitionCondition
@@ -97,7 +71,7 @@ library BpmModelLib {
             return _condition.rhPrimitive.boolValue;
         }
         else {
-            (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.rhData, _dataStorage);
+            (address dataStorage, bytes32 dataPath) = _condition.rhData.resolveDataLocation(DataStorage(_dataStorage));
             return DataStorage(dataStorage).getDataValueAsBool(dataPath);
         }
     }
@@ -118,7 +92,7 @@ library BpmModelLib {
             return _condition.rhPrimitive.addressValue;
         }
         else {
-            (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.rhData, _dataStorage);
+            (address dataStorage, bytes32 dataPath) = _condition.rhData.resolveDataLocation(DataStorage(_dataStorage));
             return DataStorage(dataStorage).getDataValueAsAddress(dataPath);
         }
     }
@@ -139,7 +113,7 @@ library BpmModelLib {
             return _condition.rhPrimitive.bytes32Value;
         }
         else {
-            (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.rhData, _dataStorage);
+            (address dataStorage, bytes32 dataPath) = _condition.rhData.resolveDataLocation(DataStorage(_dataStorage));
             return DataStorage(dataStorage).getDataValueAsBytes32(dataPath);
         }
     }
@@ -160,7 +134,7 @@ library BpmModelLib {
             return _condition.rhPrimitive.stringValue;
         }
         else {
-            (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.rhData, _dataStorage);
+            (address dataStorage, bytes32 dataPath) = _condition.rhData.resolveDataLocation(DataStorage(_dataStorage));
             return DataStorage(dataStorage).getDataValueAsString(dataPath);
         }
     }
@@ -181,7 +155,7 @@ library BpmModelLib {
             return _condition.rhPrimitive.uintValue;
         }
         else {
-            (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.rhData, _dataStorage);
+            (address dataStorage, bytes32 dataPath) = _condition.rhData.resolveDataLocation(DataStorage(_dataStorage));
             return DataStorage(dataStorage).getDataValueAsUint(dataPath);
         }
     }
@@ -202,7 +176,7 @@ library BpmModelLib {
             return _condition.rhPrimitive.intValue;
         }
         else {
-            (address dataStorage, bytes32 dataPath) = resolveConditionalDataLocation(_condition.rhData, _dataStorage);
+            (address dataStorage, bytes32 dataPath) = _condition.rhData.resolveDataLocation(DataStorage(_dataStorage));
             return DataStorage(dataStorage).getDataValueAsInt(dataPath);
         }
     }

--- a/contracts/src/build-test-commons-collections.yaml
+++ b/contracts/src/build-test-commons-collections.yaml
@@ -27,6 +27,10 @@ jobs:
     build:
       contract: commons-collections/test/DataStorageTest.sol
       instance: DataStorageTest
+  - name: DataStorageUtilsTest
+    build:
+      contract: commons-collections/test/DataStorageUtilsTest.sol
+      instance: DataStorageUtilsTest
   - name: VersionLinkedTest
     build:
       contract: commons-collections/test/VersionLinkedTest.sol

--- a/contracts/src/commons-collections/AbstractAddressScopes.sol
+++ b/contracts/src/commons-collections/AbstractAddressScopes.sol
@@ -90,10 +90,10 @@ contract AbstractAddressScopes is AddressScopes {
             return addressScopes[key].scope.fixedScope;
         }
         else if (addressScopes[key].scope.conditionalScope.exists) {
-			// If the ConditionalData does not point to a DataStorage by address, the second parameter (DataStorage) is required for resolution
+			// If the ConditionalData does not point to a DataStorage by address, the second function parameter (DataStorage) is required for resolution
 			if (addressScopes[key].scope.conditionalScope.dataStorage == address(0)) {
 				ErrorsLib.revertIf(address(_dataStorage) == address(0),
-					ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "AbstractAddressScopes.getScope", "The DataStorage parameter is required for a ConditionalData scope without a fixed dataStorage address");
+					ErrorsLib.INVALID_INPUT(), "AbstractAddressScopes.getScope", "The DataStorage parameter is required for a ConditionalData scope without a fixed dataStorage address");
 			}
             (address targetDataStorage, bytes32 dataPath) = addressScopes[key].scope.conditionalScope.resolveDataLocation(_dataStorage);
 			return DataStorage(targetDataStorage).getDataValueAsBytes32(dataPath);

--- a/contracts/src/commons-collections/test/DataStorageUtilsTest.sol
+++ b/contracts/src/commons-collections/test/DataStorageUtilsTest.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.4.23;
+
+import "commons-collections/DataStorage.sol";
+import "commons-collections/FullDataStorage.sol";
+import "commons-collections/DataStorageUtils.sol";
+
+contract DataStorageUtilsTest {
+	
+	using DataStorageUtils for DataStorageUtils.ConditionalData;
+
+	string SUCCESS = "success";
+	bytes32 EMPTY = "";
+	
+	// Storage contracts used in tests
+	DataStorage myStorage;
+	DataStorage mySubDataStorage;
+	ResolverHelper helper = new ResolverHelper();
+	DataStorageUtils.ConditionalData conditionalData;	
+	
+	uint error;
+
+	function testConditionalDataHandling() external returns (string) {
+		
+		address addr;
+		bytes32 path;
+
+		myStorage = new FullDataStorage();
+		mySubDataStorage = new FullDataStorage();
+
+		myStorage.setDataValueAsAddress("subStorage", address(mySubDataStorage));
+		mySubDataStorage.setDataValueAsUint("key1", 99);
+
+		// test resolveDataStorageAddress
+		addr = DataStorageUtils.resolveDataStorageAddress("subStorage", address(0), myStorage);
+		if (addr != address(mySubDataStorage)) return "address resolution for dataStorageId should retrieve mySubDataStorage address";
+		addr = DataStorageUtils.resolveDataStorageAddress(EMPTY, address(0), myStorage);
+		if (addr != address(myStorage)) return "address resolution for empty dataStorageId should retrieve myStorage address";
+		addr = DataStorageUtils.resolveDataStorageAddress(EMPTY, address(this), mySubDataStorage);
+		if (addr != address(this)) return "address resolution using an explicit address should return that address";
+		addr = DataStorageUtils.resolveDataStorageAddress("fakePath", address(0), myStorage);
+		if (addr != address(0)) return "address resolution for non-existent dataStorageId should retrieve 0x0 address";
+		// test reverts
+		if (address(helper).call(abi.encodeWithSignature("resolveDataStorageAddress(bytes32,address,address)", bytes32("subStorage"), address(0), address(0))))
+			return "Address resolution with a dataStorageId and an empty DataStorage should revert";
+
+		conditionalData = DataStorageUtils.ConditionalData({dataPath: "key1", dataStorageId: "subStorage", dataStorage: address(0), exists: true});
+		(addr, path) = conditionalData.resolveDataLocation(myStorage);
+		if (addr != address(mySubDataStorage)) return "location for conditionalData should retrieve mySubDataStorage address";
+		if (path != "key1") return "location for conditionalData should retrieve key1 dataPath";
+		// test reverts
+		if (address(helper).call(abi.encodeWithSignature("resolveDataLocation(bytes32,bytes32,address,address)", bytes32("key1"), bytes32("bogusStoriddgeID"), address(0), address(myStorage))))
+			return "Location resolution with non-existent dataStorageId should revert";
+
+		return SUCCESS;
+	}
+
+}
+
+/**
+ * @dev Helper contract to wrap the library functions and make them .call() -able
+ */
+contract ResolverHelper {
+
+	DataStorageUtils.ConditionalData conditionalData;	
+
+	function resolveDataStorageAddress(bytes32 _dataStorageId, address _dataStorageAddress, DataStorage _refDataStorage) public view returns (address) {
+		return DataStorageUtils.resolveDataStorageAddress(_dataStorageId, _dataStorageAddress, _refDataStorage);
+	}
+
+  	function resolveDataLocation(bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, address _refDataStorage)
+		public
+    	returns (address dataStorage, bytes32 dataPath)
+	{
+		conditionalData = DataStorageUtils.ConditionalData({dataPath: _dataPath, dataStorageId: _dataStorageId, dataStorage: _dataStorage, exists: true});
+		return DataStorageUtils.resolveDataLocation(conditionalData, DataStorage(_refDataStorage));
+	}
+
+}

--- a/contracts/src/test-commons-collections.yaml
+++ b/contracts/src/test-commons-collections.yaml
@@ -1,6 +1,4 @@
 
-##########
-# Mappings
 jobs:
 
 - name: ErrorsLib
@@ -27,167 +25,190 @@ jobs:
     instance: DataStorageUtils
     libraries: ErrorsLib:$ErrorsLib, TypeUtilsAPI:$TypeUtilsAPI, MappingsLib:$MappingsLib
 
-# - name: MappingsLibTest
-#   deploy:
-#     contract: MappingsLibTest.bin
-#     instance: MappingsLibTest
-#     libraries: MappingsLib:$MappingsLib
+#####
+# MappingLib Test
+- name: MappingsLibTest
+  deploy:
+    contract: MappingsLibTest.bin
+    instance: MappingsLibTest
+    libraries: MappingsLib:$MappingsLib
 
-# - name: testBytes32AddressMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testBytes32AddressMap
+- name: testBytes32AddressMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testBytes32AddressMap
 
-# - name: assertBytes32AddressMap
-#   assert:
-#     key: $testBytes32AddressMap
-#     relation: eq
-#     val: success
+- name: assertBytes32AddressMap
+  assert:
+    key: $testBytes32AddressMap
+    relation: eq
+    val: success
 
-# - name: testBytes32Bytes32Map
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testBytes32Bytes32Map
+- name: testBytes32Bytes32Map
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testBytes32Bytes32Map
 
-# - name: assertBytes32Bytes32Map
-#   assert:
-#     key: $testBytes32Bytes32Map
-#     relation: eq
-#     val: success
+- name: assertBytes32Bytes32Map
+  assert:
+    key: $testBytes32Bytes32Map
+    relation: eq
+    val: success
 
-# - name: testBytes32UintMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testBytes32UintMap
+- name: testBytes32UintMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testBytes32UintMap
 
-# - name: assertBytes32UintMap
-#   assert:
-#     key: $testBytes32UintMap
-#     relation: eq
-#     val: success
+- name: assertBytes32UintMap
+  assert:
+    key: $testBytes32UintMap
+    relation: eq
+    val: success
 
-# - name: testBytes32AddressArrayMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testBytes32AddressArrayMap
+- name: testBytes32AddressArrayMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testBytes32AddressArrayMap
 
-# - name: assertBytes32AddressArrayMap
-#   assert:
-#     key: $testBytes32AddressArrayMap
-#     relation: eq
-#     val: success
+- name: assertBytes32AddressArrayMap
+  assert:
+    key: $testBytes32AddressArrayMap
+    relation: eq
+    val: success
 
-# - name: testAddressBytes32Map
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testAddressBytes32Map
+- name: testAddressBytes32Map
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testAddressBytes32Map
 
-# - name: assertAddressBytes32Map
-#   assert:
-#     key: $testAddressBytes32Map
-#     relation: eq
-#     val: success
+- name: assertAddressBytes32Map
+  assert:
+    key: $testAddressBytes32Map
+    relation: eq
+    val: success
 
-# - name: testAddressBoolMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testAddressBoolMap
+- name: testAddressBoolMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testAddressBoolMap
 
-# - name: assertAddressBoolMap
-#   assert:
-#     key: $testAddressBoolMap
-#     relation: eq
-#     val: success
+- name: assertAddressBoolMap
+  assert:
+    key: $testAddressBoolMap
+    relation: eq
+    val: success
 
-# - name: testAddressBytes32ArrayMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testAddressBytes32ArrayMap
+- name: testAddressBytes32ArrayMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testAddressBytes32ArrayMap
 
-# - name: assertAddressBytes32ArrayMap
-#   assert:
-#     key: $testAddressBytes32ArrayMap
-#     relation: eq
-#     val: success
+- name: assertAddressBytes32ArrayMap
+  assert:
+    key: $testAddressBytes32ArrayMap
+    relation: eq
+    val: success
 
-# - name: testAddressAddressMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testAddressAddressMap
+- name: testAddressAddressMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testAddressAddressMap
 
-# - name: assertAddressAddressMap
-#   assert:
-#     key: $testAddressAddressMap
-#     relation: eq
-#     val: success
+- name: assertAddressAddressMap
+  assert:
+    key: $testAddressAddressMap
+    relation: eq
+    val: success
 
-# - name: testUintAddressMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testUintAddressMap
+- name: testUintAddressMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testUintAddressMap
 
-# - name: assertUintAddressMap
-#   assert:
-#     key: $testUintAddressMap
-#     relation: eq
-#     val: success
+- name: assertUintAddressMap
+  assert:
+    key: $testUintAddressMap
+    relation: eq
+    val: success
 
-# - name: testAddressAddressArrayMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testAddressAddressArrayMap
+- name: testAddressAddressArrayMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testAddressAddressArrayMap
 
-# - name: assertAddressAddressArrayMap
-#   assert:
-#     key: $testAddressAddressArrayMap
-#     relation: eq
-#     val: success
+- name: assertAddressAddressArrayMap
+  assert:
+    key: $testAddressAddressArrayMap
+    relation: eq
+    val: success
 
-# - name: testUintAddressArrayMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testUintAddressArrayMap
+- name: testUintAddressArrayMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testUintAddressArrayMap
 
-# - name: assertUintAddressArrayMap
-#   assert:
-#     key: $testUintAddressArrayMap
-#     relation: eq
-#     val: success
+- name: assertUintAddressArrayMap
+  assert:
+    key: $testUintAddressArrayMap
+    relation: eq
+    val: success
 
-# - name: testUintBytes32ArrayMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testUintBytes32ArrayMap
+- name: testUintBytes32ArrayMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testUintBytes32ArrayMap
 
-# - name: assertUintBytes32ArrayMap
-#   assert:
-#     key: $testUintBytes32ArrayMap
-#     relation: eq
-#     val: success
+- name: assertUintBytes32ArrayMap
+  assert:
+    key: $testUintBytes32ArrayMap
+    relation: eq
+    val: success
 
-# - name: testStringAddressMap
-#   call:
-#     destination: $MappingsLibTest
-#     bin: MappingsLibTest
-#     function: testStringAddressMap
+- name: testStringAddressMap
+  call:
+    destination: $MappingsLibTest
+    bin: MappingsLibTest
+    function: testStringAddressMap
 
-# - name: assertStringAddressMap
-#   assert:
-#     key: $testStringAddressMap
-#     relation: eq
-#     val: success
+- name: assertStringAddressMap
+  assert:
+    key: $testStringAddressMap
+    relation: eq
+    val: success
+
+#####
+# DataStorageUtils Test
+- name: DataStorageUtilsTest
+  deploy:
+    contract: DataStorageUtilsTest.bin
+    instance: DataStorageUtilsTest
+    libraries: ErrorsLib:$ErrorsLib, DataStorageUtils:$DataStorageUtils
+
+- name: testConditionalDataHandling
+  call:
+    destination: $DataStorageUtilsTest
+    bin: DataStorageUtilsTest
+    function: testConditionalDataHandling
+
+- name: assertConditionalDataHandling
+  assert:
+    key: $testConditionalDataHandling
+    relation: eq
+    val: success
+
 
 #####
 # DataStorage Test


### PR DESCRIPTION
This PR fixes a bug where the placeholder `PROCESS_INSTANCE` was not removed as a dataStorageId prior to setting transition conditions in the smart contracts. An empty string needs to be passed since the ProcessInstance is the top DataStorage container for data resolution.
Additionally, the function DataStorageUtils.resolveDataLocation was changed to REVERT if for whatever reason a DataStorage address cannot be determined. This guarantees to consuming code that the function always returns a location that is non-zero address.

Signed-off-by: Jan Hendrik Scheufen <j.h.scheufen@gmail.com>