### PR TITLE
Bugfix: transition conditions for uint values not working

### DIFF
--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -358,11 +358,12 @@ const _generateParamSetterPromises = (agreementAddr, archetypeParamDetails, agre
   const promises = [];
   const invalidParams = [];
   agreementParams.forEach((param) => {
+    log.trace('Processing parameter data for agreement %s: %s', agreementAddr, JSON.stringify(param));
     const matchingParam = archetypeParamDetails.filter(item => param.name === item.name)[0];
     if (matchingParam) {
       const setterFunction = dataStorage.agreementDataSetters[`${matchingParam.parameterType}`];
       if (setterFunction) {
-        log.debug(`Setting value: ${param.value} for parameter: ${matchingParam.name} in agremeement at agreement address ${agreementAddr}`);
+        log.debug('Setting value: %s for parameter %s with type %d in agremeement %s', param.value, matchingParam.name, matchingParam.parameterType, agreementAddr);
         const formattedParam = format('Parameter Value', { parameterType: matchingParam.parameterType, value: param.value });
         promises.push(setterFunction(agreementAddr, matchingParam.name, formattedParam.value));
       } else {
@@ -393,7 +394,6 @@ const setAgreementParameters = async (agreeAddr, archAddr, parameters) => {
 };
 
 const createAgreement = asyncMiddleware(async (req, res) => {
-  const password = req.body.password || null;
   let parameters = req.body.parameters || [];
   parameters = await createOrFindAccountsWithEmails(parameters);
   const parties = req.body.parties || [];

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -918,7 +918,7 @@ const setDefaultTransition = (processAddress, gatewayId, activityId) => new Prom
       return reject(boom
         .badImplementation(`Failed to set default transition between gateway ${gatewayId} and activity ${activityId} in process at ${processAddress}: ${error}`));
     }
-    log.info(`Default transition set between gateway ${gatewayId} and activity ${activityId} in process at ${processAddress}`);
+    log.info(`Default transition set between gateway ${gatewayId} and model element ${activityId} in process at ${processAddress}`);
     return resolve();
   });
 });
@@ -940,7 +940,20 @@ const createTransitionCondition = (processAddress, dataType, gatewayId, activity
     processAddress, dataType, gatewayId, activityId, dataPath, dataStorageId, dataStorage, operator, value,
   }));
   const createFunction = getTransitionConditionFunctionByDataType(processAddress, dataType);
-  createFunction(gatewayId, activityId, dataPath, dataStorageId, dataStorage, operator, value, (error) => {
+  let formattedValue;
+  if (dataType === DATA_TYPES.UINT || dataType === DATA_TYPES.INT) {
+    formattedValue = parseInt(value, 10);
+    log.debug('Converted value to integer: %d', formattedValue);
+  } else if (dataType === DATA_TYPES.BOOLEAN) {
+    formattedValue = Boolean(value);
+    log.debug('Converted value to boolean: %s', formattedValue);
+  } else if (dataType === DATA_TYPES.BYTES32) {
+    formattedValue = global.stringToHex(value);
+    log.debug('Converted value to bytes32: %s', formattedValue);
+  } else {
+    formattedValue = value;
+  }
+  createFunction(gatewayId, activityId, dataPath, dataStorageId, dataStorage, operator, formattedValue, (error) => {
     if (error) {
       return reject(boom.badImplementation('Failed to add transition condition for gateway id ' +
         `${gatewayId} and activity id ${activityId} in process at address ${processAddress}: ${error}`));

--- a/api/test/data/Execution-NoAction.bpmn
+++ b/api/test/data/Execution-NoAction.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.11.3">
+  <bpmn:dataStore id="PROCESS_INSTANCE" name="Process Instance">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="agreement" value="7" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+  </bpmn:dataStore>
+  <bpmn:dataStore id="agreement" name="Agreement">
+    <bpmn:extensionElements>
+      <camunda:properties />
+    </bpmn:extensionElements>
+  </bpmn:dataStore>
+  <bpmn:collaboration id="Collaboration_1bqszqk">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="id" value="###MODEL_ID###" />
+        <camunda:property name="version" value="1.0.0" />
+        <camunda:property name="private" value="false" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:participant id="Participant_0afvvg1" name="No Action" processRef="Process_104nkeu" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_104nkeu" name="No Action" isExecutable="false">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="processInterface" value="Agreement Execution" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:laneSet id="LaneSet_08x4qvj">
+      <bpmn:lane id="Lane_18i4kvj" name="System">
+        <bpmn:flowNodeRef>Task_15irtdh</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:task id="Task_15irtdh" name="Start">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="behavior" value="0" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1bqszqk">
+      <bpmndi:BPMNShape id="Participant_0afvvg1_di" bpmnElement="Participant_0afvvg1">
+        <dc:Bounds x="246" y="152" width="678" height="252" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_18i4kvj_di" bpmnElement="Lane_18i4kvj">
+        <dc:Bounds x="276" y="152" width="648" height="252" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1seuy1m_di" bpmnElement="Task_15irtdh">
+        <dc:Bounds x="510" y="228" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/api/test/data/Formation-Tenant-XOR-Gateway.bpmn
+++ b/api/test/data/Formation-Tenant-XOR-Gateway.bpmn
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.11.3">
+  <bpmn:dataStore id="PROCESS_INSTANCE" name="Process Instance">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="agreement" value="7" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+  </bpmn:dataStore>
+  <bpmn:dataStore id="agreement" name="Agreement">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="Tenant" value="8" />
+        <camunda:property name="Building Completed" value="2" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+  </bpmn:dataStore>
+  <bpmn:collaboration id="Collaboration_1bqszqk">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="id" value="###MODEL_ID###" />
+        <camunda:property name="version" value="1.0.0" />
+        <camunda:property name="private" value="false" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:participant id="Participant_0afvvg1" name="Rental Agreement w/ Disclosures" processRef="Process_104nkeu" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_104nkeu" name="Rental Agreement w/ Disclosures" isExecutable="false">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="processInterface" value="Agreement Formation" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:laneSet id="LaneSet_08x4qvj">
+      <bpmn:lane id="Lane_18i4kvj" name="System">
+        <bpmn:flowNodeRef>Task_15irtdh</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_1y8713o</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_1sqcpt1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_0ky8n9d</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_1qvrgtf" name="Tenant">
+        <bpmn:extensionElements>
+          <camunda:properties>
+            <camunda:property name="conditionalPerformer" value="true" />
+            <camunda:property name="dataStorageId" value="agreement" />
+            <camunda:property name="dataPath" value="Tenant" />
+          </camunda:properties>
+        </bpmn:extensionElements>
+        <bpmn:flowNodeRef>Task_1jrtitw</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:task id="Task_15irtdh" name="Start">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="behavior" value="0" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_1hs2xx1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_1hs2xx1" name="" sourceRef="Task_15irtdh" targetRef="ExclusiveGateway_1y8713o">
+      <bpmn:extensionElements>
+        <camunda:properties />
+      </bpmn:extensionElements>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1y8713o" default="SequenceFlow_0e1p2ph">
+      <bpmn:incoming>SequenceFlow_1hs2xx1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_10xdyzg</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0e1p2ph</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_10xdyzg" name="Building Completed &#60; 1978" sourceRef="ExclusiveGateway_1y8713o" targetRef="Task_1jrtitw">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="lhDataStorageId" value="agreement" />
+          <camunda:property name="lhDataPath" value="Building Completed" />
+          <camunda:property name="operator" value="1" />
+          <camunda:property name="rhValue" value="1978" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_0e1p2ph" name="" sourceRef="ExclusiveGateway_1y8713o" targetRef="ExclusiveGateway_1sqcpt1">
+      <bpmn:extensionElements>
+        <camunda:properties />
+      </bpmn:extensionElements>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1riranq" sourceRef="ExclusiveGateway_1sqcpt1" targetRef="Task_0ky8n9d" />
+    <bpmn:sequenceFlow id="SequenceFlow_0dkrlyy" name="" sourceRef="Task_1jrtitw" targetRef="ExclusiveGateway_1sqcpt1">
+      <bpmn:extensionElements>
+        <camunda:properties />
+      </bpmn:extensionElements>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1sqcpt1">
+      <bpmn:incoming>SequenceFlow_0dkrlyy</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0e1p2ph</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1riranq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Task_0ky8n9d" name="End">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="behavior" value="0" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1riranq</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:userTask id="Task_1jrtitw" name="Sign Lead Paint Disclosure">
+      <bpmn:incoming>SequenceFlow_10xdyzg</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0dkrlyy</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1bqszqk">
+      <bpmndi:BPMNShape id="Participant_0afvvg1_di" bpmnElement="Participant_0afvvg1">
+        <dc:Bounds x="246" y="152" width="678" height="252" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_18i4kvj_di" bpmnElement="Lane_18i4kvj">
+        <dc:Bounds x="276" y="152" width="648" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1qvrgtf_di" bpmnElement="Lane_1qvrgtf">
+        <dc:Bounds x="276" y="277" width="648" height="127" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1seuy1m_di" bpmnElement="Task_15irtdh">
+        <dc:Bounds x="333" y="171" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1y8713o_di" bpmnElement="ExclusiveGateway_1y8713o" isMarkerVisible="true">
+        <dc:Bounds x="466" y="186" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1hs2xx1_di" bpmnElement="SequenceFlow_1hs2xx1">
+        <di:waypoint x="433" y="211" />
+        <di:waypoint x="466" y="211" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10xdyzg_di" bpmnElement="SequenceFlow_10xdyzg">
+        <di:waypoint x="491" y="236" />
+        <di:waypoint x="491" y="337" />
+        <di:waypoint x="547" y="337" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="403" y="308" width="63" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1sqcpt1_di" bpmnElement="ExclusiveGateway_1sqcpt1" isMarkerVisible="true">
+        <dc:Bounds x="698" y="186" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0e1p2ph_di" bpmnElement="SequenceFlow_0e1p2ph">
+        <di:waypoint x="516" y="211" />
+        <di:waypoint x="698" y="211" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="474" y="160" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1riranq_di" bpmnElement="SequenceFlow_1riranq">
+        <di:waypoint x="748" y="211" />
+        <di:waypoint x="769" y="211" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dkrlyy_di" bpmnElement="SequenceFlow_0dkrlyy">
+        <di:waypoint x="647" y="337" />
+        <di:waypoint x="723" y="337" />
+        <di:waypoint x="723" y="236" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Task_1xchij5_di" bpmnElement="Task_0ky8n9d">
+        <dc:Bounds x="769" y="171" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1e6lnsm_di" bpmnElement="Task_1jrtitw">
+        <dc:Bounds x="547" y="297" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/contracts/src/bpm-model/ProcessDefinition.sol
+++ b/contracts/src/bpm-model/ProcessDefinition.sol
@@ -67,6 +67,13 @@ contract ProcessDefinition is Bytes32Identifiable {
 	function createTransition(bytes32 _source, bytes32 _target) external returns (uint error);
 
 	/**
+	 * @dev Sets the specified activity to be the default output (default transition) of the specified gateway.
+	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
+	 */
+	function setDefaultTransition(bytes32 _gatewayId, bytes32 _targetElementId) external;
+
+	/**
 	 * @dev Create a data mapping for the specified activity and direction.
 	 * @param _activityId the ID of the activity in this ProcessDefinition
 	 * @param _direction the BpmModel.Direction [IN|OUT]
@@ -89,86 +96,86 @@ contract ProcessDefinition is Bytes32Identifiable {
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The parameters dataPath, dataStorageId, and dataStorage are used to construct a left-hand side DataStorageUtils.ConditionalData object.
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _dataPath the left-hand side dataPath condition
 	 * @param _dataStorageId the left-hand side dataStorageId condition
 	 * @param _dataStorage the left-hand side dataStorage condition
 	 * @param _operator the uint8 representation of a DataStorageUtils.COMPARISON_OPERATOR
 	 * @param _value the right-hand side comparison value
 	 */
-	function createTransitionConditionForString(bytes32 _gatewayId, bytes32 _activityId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, string _value) external;
+	function createTransitionConditionForString(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, string _value) external;
 
 	/**
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The parameters dataPath, dataStorageId, and dataStorage are used to construct a left-hand side DataStorageUtils.ConditionalData object.
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _dataPath the left-hand side dataPath condition
 	 * @param _dataStorageId the left-hand side dataStorageId condition
 	 * @param _dataStorage the left-hand side dataStorage condition
 	 * @param _operator the uint8 representation of a DataStorageUtils.COMPARISON_OPERATOR
 	 * @param _value the right-hand side comparison value
 	 */
-	function createTransitionConditionForBytes32(bytes32 _gatewayId, bytes32 _activityId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, bytes32 _value) external;
+	function createTransitionConditionForBytes32(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, bytes32 _value) external;
 
 	/**
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The parameters dataPath, dataStorageId, and dataStorage are used to construct a left-hand side DataStorageUtils.ConditionalData object.
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _dataPath the left-hand side dataPath condition
 	 * @param _dataStorageId the left-hand side dataStorageId condition
 	 * @param _dataStorage the left-hand side dataStorage condition
 	 * @param _operator the uint8 representation of a DataStorageUtils.COMPARISON_OPERATOR
 	 * @param _value the right-hand side comparison value
 	 */
-	function createTransitionConditionForAddress(bytes32 _gatewayId, bytes32 _activityId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, address _value) external;
+	function createTransitionConditionForAddress(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, address _value) external;
 
 	/**
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The parameters dataPath, dataStorageId, and dataStorage are used to construct a left-hand side DataStorageUtils.ConditionalData object.
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _dataPath the left-hand side dataPath condition
 	 * @param _dataStorageId the left-hand side dataStorageId condition
 	 * @param _dataStorage the left-hand side dataStorage condition
 	 * @param _operator the uint8 representation of a DataStorageUtils.COMPARISON_OPERATOR
 	 * @param _value the right-hand side comparison value
 	 */
-	function createTransitionConditionForBool(bytes32 _gatewayId, bytes32 _activityId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, bool _value) external;
+	function createTransitionConditionForBool(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, bool _value) external;
 
 	/**
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The parameters dataPath, dataStorageId, and dataStorage are used to construct a left-hand side DataStorageUtils.ConditionalData object.
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _dataPath the left-hand side dataPath condition
 	 * @param _dataStorageId the left-hand side dataStorageId condition
 	 * @param _dataStorage the left-hand side dataStorage condition
 	 * @param _operator the uint8 representation of a DataStorageUtils.COMPARISON_OPERATOR
 	 * @param _value the right-hand side comparison value
 	 */
-	function createTransitionConditionForUint(bytes32 _gatewayId, bytes32 _activityId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, uint _value) external;
+	function createTransitionConditionForUint(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, uint _value) external;
 
 	/**
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The parameters dataPath, dataStorageId, and dataStorage are used to construct a left-hand side DataStorageUtils.ConditionalData object.
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _dataPath the left-hand side dataPath condition
 	 * @param _dataStorageId the left-hand side dataStorageId condition
 	 * @param _dataStorage the left-hand side dataStorage condition
 	 * @param _operator the uint8 representation of a DataStorageUtils.COMPARISON_OPERATOR
 	 * @param _value the right-hand side comparison value
 	 */
-	function createTransitionConditionForInt(bytes32 _gatewayId, bytes32 _activityId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, int _value) external;
+	function createTransitionConditionForInt(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage, uint8 _operator, int _value) external;
 
 	/**
 	 * @dev Creates a transition condition between the specified gateway and activity using the given parameters.
 	 * The "lh..." parameters are used to construct a left-hand side DataStorageUtils.ConditionalData object while the "rh..." ones are used
 	 * for a right-hand side DataStorageUtils.ConditionalData as comparison
 	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
+	 * @param _targetElementId the ID of a graph element (activity or gateway) in this ProcessDefinition
 	 * @param _lhDataPath the left-hand side dataPath condition
 	 * @param _lhDataStorageId the left-hand side dataStorageId condition
 	 * @param _lhDataStorage the left-hand side dataStorage condition
@@ -177,14 +184,7 @@ contract ProcessDefinition is Bytes32Identifiable {
 	 * @param _rhDataStorageId the right-hand side dataStorageId condition
 	 * @param _rhDataStorage the right-hand side dataStorage condition
 	 */
-	function createTransitionConditionForDataStorage(bytes32 _gatewayId, bytes32 _activityId, bytes32 _lhDataPath, bytes32 _lhDataStorageId, address _lhDataStorage, uint8 _operator, bytes32 _rhDataPath, bytes32 _rhDataStorageId, address _rhDataStorage) external;
-
-	/**
-	 * @dev Sets the specified activity to be the default output (default transition) of the specified gateway.
-	 * @param _gatewayId the ID of a gateway in this ProcessDefinition
-	 * @param _activityId the ID of an activity in this ProcessDefinition
-	 */
-	function setDefaultTransition(bytes32 _gatewayId, bytes32 _activityId) external;
+	function createTransitionConditionForDataStorage(bytes32 _gatewayId, bytes32 _targetElementId, bytes32 _lhDataPath, bytes32 _lhDataStorageId, address _lhDataStorage, uint8 _operator, bytes32 _rhDataPath, bytes32 _rhDataStorageId, address _rhDataStorage) external;
 
 	/**
 	 * @dev Resolves a transition condition between the given source and target model elements using the provided DataStorage to lookup data.

--- a/contracts/src/bpm-runtime/BpmRuntimeLib.sol
+++ b/contracts/src/bpm-runtime/BpmRuntimeLib.sol
@@ -871,7 +871,8 @@ library BpmRuntimeLib {
                 traverseRuntimeGraph(_processDefinition, targetId, _graph);
                 targetType = _processDefinition.getElementType(targetId);
                 bytes32 newElementId = connect(_graph, _currentId, currentType, targetId, targetType);
-                // if the current target is the gateway's defaultOutput, set it considering the potential creation of an artificial place (newElementId)
+                // If the ProcessDefinition defines the target of the just made connection to be the default, it needs to be set in the graph
+                // For the graph, however, the target can be the original target (=activity) or a newly inserted place (newElementId), if the PD's target is another gateway.
                 if (defaultOutput == targetId) {
                     _graph.transitions[_currentId].defaultOutput = (newElementId != "") ? newElementId : targetId;
                 }

--- a/contracts/src/commons-collections/test/DataStorageTest.sol
+++ b/contracts/src/commons-collections/test/DataStorageTest.sol
@@ -44,7 +44,7 @@ contract DataStorageTest {
 	bytes32 wonderwoman = "wonderwoman";
 
 	bytes32 num10 = "num10";
-	uint ten = 10;
+	uint tenVal = 10;
 	bytes32 trueVal = "trueVal";
 	bool truthy = true;
 	bytes32 marmot = "marmot";
@@ -183,8 +183,9 @@ contract DataStorageTest {
 		myStorage.setDataValueAsAddress(subStorageId, mySubDataStorage);
 		
 		// compare uints
-		myStorage.setDataValueAsUintType(num10, ten, DataTypes.UINT256());
-		result = DataStorageUtils.resolveExpression(myStorage, EMPTY, num10, DataStorageUtils.COMPARISON_OPERATOR.EQ, ten);
+		myStorage.setDataValueAsUint(num10, tenVal);
+		mySubDataStorage.setDataValueAsUint("num2000", uint(2000));
+		result = DataStorageUtils.resolveExpression(myStorage, EMPTY, num10, DataStorageUtils.COMPARISON_OPERATOR.EQ, tenVal);
 		if (result != true) return "Expected 10 == 10 to be true";
 
 		result = DataStorageUtils.resolveExpression(myStorage, EMPTY, num10, DataStorageUtils.COMPARISON_OPERATOR.NEQ, uint(12));
@@ -195,6 +196,13 @@ contract DataStorageTest {
 
 		result = DataStorageUtils.resolveExpression(myStorage, EMPTY, num10, DataStorageUtils.COMPARISON_OPERATOR.GT, uint(12));
 		if (result != false) return "Expected 10 > 12 to be false";
+
+		// uint in substorage
+		result = DataStorageUtils.resolveExpression(myStorage, subStorageId, "num2000", DataStorageUtils.COMPARISON_OPERATOR.GTE, uint(2000));
+		if (result != true) return "Expected 2000 >= 2000 to be true";
+
+		result = DataStorageUtils.resolveExpression(myStorage, subStorageId, "num2000", DataStorageUtils.COMPARISON_OPERATOR.GTE, uint(2001));
+		if (result != false) return "Expected 2000 >= 2001 to be false";
 
 		// compare bools
 		myStorage.setDataValueAsBool(trueVal, truthy);
@@ -227,7 +235,7 @@ contract DataStorageTest {
 
 		// compare uint in substorage
 		mySubDataStorage.setDataValueAsUintType(num10, 10, DataTypes.UINT256());
-		result = DataStorageUtils.resolveExpression(myStorage, subStorageId, num10, DataStorageUtils.COMPARISON_OPERATOR.EQ, ten);
+		result = DataStorageUtils.resolveExpression(myStorage, subStorageId, num10, DataStorageUtils.COMPARISON_OPERATOR.EQ, tenVal);
 		if (result != true) return "Expected 10 == 10 to be true in substorage";
 
 		return SUCCESS;

--- a/contracts/src/test-bpm-runtime.yaml
+++ b/contracts/src/test-bpm-runtime.yaml
@@ -289,6 +289,18 @@ jobs:
     relation: eq
     val: success
 
+- name: testSuccessiveGatewaysRoute
+  call:
+    destination: $BpmServiceTest
+    bin: BpmServiceTest
+    function: testSuccessiveGatewaysRoute
+
+- name: assertSuccessiveGatewaysRoute
+  assert:
+    key: $testSuccessiveGatewaysRoute
+    relation: eq
+    val: success
+
 - name: testSequentialServiceApplications
   call:
     destination: $BpmServiceTest


### PR DESCRIPTION
This is a fix for uint conditions on XOR gateways seemingly not working. Integers were set in the smart contracts that differed from the intended ones due to burrow.js conversions triggered by blackstone sending string values. Blackstone now converts the value appropriately before calling the smart contracts.
This PR also includes support for successive gateways such that no "pass-thru" (NONE) activity is needed anymore between two gateways.