### PR TITLE
Remove contract change listeners on upgrade

### DIFF
--- a/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
@@ -785,5 +785,16 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		ActiveAgreement(_activeAgreement).setEventLogReference(_eventLogHoardAddress, _eventLogHoardSecret);
 		emit LogAgreementEventLogReference(EVENT_ID_AGREEMENTS, _activeAgreement, _eventLogHoardAddress, _eventLogHoardSecret);
 	 }
-	
+
+	/**
+	 * @dev Overwrites the Upgradeable.upgrade(address) function to remove this contract as a contract change listener.
+	 */
+    function upgrade(address _successor) public returns (bool success) {
+        success = super.upgrade(_successor);
+        if (success && address(locator) != address(0)) {
+            locator.removeContractChangeListener(serviceIdArchetypeRegistry);
+            locator.removeContractChangeListener(serviceIdBpmService);
+        }
+    }
+
 }

--- a/contracts/src/bpm-runtime/DefaultBpmService.sol
+++ b/contracts/src/bpm-runtime/DefaultBpmService.sol
@@ -430,4 +430,16 @@ contract DefaultBpmService is Versioned(1,0,0), AbstractDbUpgradeable, ContractL
             ProcessInstance(_processInstance).getState()
         );
     }
+
+	/**
+	 * @dev Overwrites the Upgradeable.upgrade(address) function to remove this contract as a contract change listener.
+	 */
+    function upgrade(address _successor) public returns (bool success) {
+        success = super.upgrade(_successor);
+        if (success && address(locator) != address(0)) {
+            locator.removeContractChangeListener(serviceIdApplicationRegistry);
+            locator.removeContractChangeListener(serviceIdProcessModelRepository);
+        }
+    }
+
 }

--- a/contracts/src/commons-auth/DefaultUserAccount.sol
+++ b/contracts/src/commons-auth/DefaultUserAccount.sol
@@ -58,6 +58,7 @@ contract DefaultUserAccount is UserAccount {
         }
         account.exists = true;
     }
+    
     /**
      * @dev Forwards a call to the specified target using the given bytes message.
      * @param _target the address to call

--- a/contracts/src/commons-management/DefaultContractManager.sol
+++ b/contracts/src/commons-management/DefaultContractManager.sol
@@ -22,6 +22,9 @@ contract DefaultContractManager is Versioned(1,0,0), SystemOwned, AbstractDbUpgr
 	bytes4 constant ERC165_ID_Versioned = bytes4(keccak256(abi.encodePacked("getVersion()")));
 	bytes4 constant ERC165_ID_Upgradeable = bytes4(keccak256(abi.encodePacked("upgrade(address)")));
 
+    /**
+     * @dev Creates a new DefaultContractManager and sets the msg.sender as the systemOwner.
+     */
     constructor() public {
         systemOwner = msg.sender;
     }

--- a/contracts/src/commons-management/test/DougTest.sol
+++ b/contracts/src/commons-management/test/DougTest.sol
@@ -29,6 +29,7 @@ contract DougTest {
         TestService s1 = new TestService([1,0,0], "");
         TestService s2 = new TestService([2,0,0], keyService1); // service2 depends on service1
         TestService s3 = new TestService([3,0,0], keyService2); // service3 depends on service2
+
         s1.transferUpgradeOwnership(doug);
         s2.transferUpgradeOwnership(doug);
         s3.transferUpgradeOwnership(doug);
@@ -46,6 +47,17 @@ contract DougTest {
         if (s2.dependencyService() != address(s1)) return "TestService2 should have s1 as dependency";
         if (s3.dependencyService() != address(s2)) return "TestService3 should have s2 as dependency";
 
+        // test upgrading services
+        TestService s2_1 = new TestService([3,1,0], keyService1);
+        s2_1.transferUpgradeOwnership(doug);
+        if (!doug.deployContract(keyService2, s2_1)) return "Deployment of TestService2_1 should succeed";
+        if (s2_1.dependencyService() != address(s1)) return "TestService2_1 should have s1 as dependency after upgrade";
+        if (s3.dependencyService() != address(s2_1)) return "TestService3 should have s2_1 as dependency after upgrade";
+
+        listeners = contractsDb.getContractChangeListeners(keyService1);
+        if (listeners.length != 1 && listeners[0] != address(s2_1)) return "TestService2_1 should now be a listener for changes to TestService1 instead of its predecessor";
+
         return "success";
     }
+
 }

--- a/contracts/src/commons-management/test/TestService.sol
+++ b/contracts/src/commons-management/test/TestService.sol
@@ -44,4 +44,10 @@ contract TestService is AbstractUpgradeable, ContractLocatorEnabled {
         success = true;
     }
 
+    function upgrade(address _successor) public returns (bool success) { 
+        success = super.upgrade(_successor);
+        if (success && address(locator) != address(0)) {
+            locator.removeContractChangeListener(dependencyKey);
+        }
+    }
 }


### PR DESCRIPTION
This PR enhances certain services that are registered in DOUG's ContractManager in order to listen for changes to contract dependencies and removes them from the list of listeners after an upgrade.