### PR TITLE
[AN-576] : [UserIdHasing] - User id is now pre-hashed in api

### DIFF
--- a/api/common/controller-dependencies.js
+++ b/api/common/controller-dependencies.js
@@ -356,6 +356,8 @@ const dependencies = {
     return false;
   },
 
+  getSHA256Hash: data => crypto.createHash('sha256').update(data).digest('hex'),
+
 };
 
 module.exports = dependencies;

--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -14,6 +14,7 @@ const {
   addMeta,
   asyncMiddleware,
   getBooleanFromString,
+  getSHA256Hash,
 } = require(`${global.__common}/controller-dependencies`);
 const pool = require(`${global.__common}/postgres-db`);
 const contracts = require('./contracts-controller');
@@ -329,7 +330,7 @@ const createOrFindAccountsWithEmails = async (params) => {
       });
       const createNewUserPromises = (Object.keys(newParams.forNewUser)).map(async (email) => {
         // Create user on chain
-        const address = await contracts.createUser({ id: email });
+        const address = await contracts.createUser({ id: getSHA256Hash(email) });
         const password = crypto.randomBytes(32).toString('hex');
         const salt = await bcrypt.genSalt(10);
         const hash = await bcrypt.hash(password, salt);

--- a/api/controllers/participants-controller.js
+++ b/api/controllers/participants-controller.js
@@ -9,6 +9,7 @@ const {
   setUserIds,
   getNamesOfOrganizations,
   asyncMiddleware,
+  getSHA256Hash,
 } = require(`${global.__common}/controller-dependencies`);
 const contracts = require('./contracts-controller');
 const logger = require(`${global.__common}/monax-logger`);
@@ -192,7 +193,7 @@ const removeDepartmentUser = asyncMiddleware(async (req, res) => {
 
 const _userExistsOnChain = async (id) => {
   try {
-    await contracts.getUserById(id);
+    await contracts.getUserById(getSHA256Hash(id));
     return true;
   } catch (err) {
     if (err.output.statusCode === 404) {
@@ -226,7 +227,7 @@ const registerUser = asyncMiddleware(async ({ body }, res) => {
   if (userInCache) throw boom.badData(`Username ${id} already exists`);
 
   // create user on chain
-  const address = await contracts.createUser({ id });
+  const address = await contracts.createUser({ id: getSHA256Hash(id) });
   const salt = await bcrypt.genSalt(10);
   const hash = await bcrypt.hash(password, salt);
 

--- a/api/controllers/postgres-query-helper.js
+++ b/api/controllers/postgres-query-helper.js
@@ -415,12 +415,9 @@ const getActivityInstances = ({ processAddress, agreementAddress }) => {
     'LEFT JOIN process_data pdat ON ai.process_instance_address = pdat.process_instance_address ' +
     'LEFT JOIN agreements agr ON agr.agreement_address = pdat.address_value ' +
     'WHERE pdat.data_id = \'agreement\'' + // Hard-coded dataId 'agreement' which all processes in the Agreements Network have
-    `${(processAddress ? ' AND ai.process_instance_address = $1' : '')}` +
-    `${(agreementAddress ? ' AND pdat.address_value = $2;' : ';')}`;
-  const params = [];
-  if (processAddress) params.push(processAddress);
-  if (agreementAddress) params.push(agreementAddress);
-  return runQuery(queryString, params)
+    `${(processAddress ? ` AND ai.process_instance_address = '${processAddress}'` : '')}` +
+    `${(agreementAddress ? ` AND pdat.address_value = '${agreementAddress}';` : ';')}`;
+  return runQuery(queryString)
     .catch((err) => { throw boom.badImplementation(`Failed to get activities: ${err}`); });
 };
 

--- a/api/data/seeds.js
+++ b/api/data/seeds.js
@@ -1,7 +1,7 @@
 const pool = require(__common + '/postgres-db');
 const contracts = require(__controllers + '/contracts-controller');
 const bcrypt = require('bcryptjs');
-const { rightPad, format } = require(__common + '/controller-dependencies');
+const { getSHA256Hash } = require(__common + '/controller-dependencies');
 
 module.exports = {
   users: (req, res, next, log) => {
@@ -58,7 +58,7 @@ module.exports = {
     });
 
     const userPromises = users.map(async ({ email, password, organization }) => {
-      const address = await contracts.createUser({ id: email });
+      const address = await contracts.createUser({ id: getSHA256Hash(email) });
       const client = await pool.connect();
       await client.query({
         text: 'DELETE FROM users WHERE email = $1',

--- a/api/migrations/20181106211133-change-username-column-size.js
+++ b/api/migrations/20181106211133-change-username-column-size.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.changeColumn('users', 'username', { type: 'varchar(255)' });
+};
+
+exports.down = function(db) {
+  return db.changeColumn('users', 'username', { type: 'varchar(20)' });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/scripts/migrateUsers.js
+++ b/api/scripts/migrateUsers.js
@@ -4,6 +4,7 @@ const toml = require('toml')
 const path = require('path')
 const _ = require('lodash')
 const monax = require('@monax/burrow')
+const crypto = require('crypto');
 
 // Set up global directory constants
 global.__common = path.resolve(__dirname, '../', 'common')
@@ -82,12 +83,13 @@ global.__monax_constants = require(path.join(__common, 'monax-constants'));
       try {
         // See if user already exists on chain first, and if they do, just return the existing address
         // This is in case this script is run after users have signed up on the new chain
-        const { address } = await contracts.getUserById(username)
+        const hashedId = crypto.createHash('sha256').update(username).digest('hex');
+        const { address } = await contracts.getUserById(hashedId)
         log.info(`User ${username} already exists at address: ${address}`)
         return new Promise((resolve) => resolve({}))
       } catch (err) {
         // If not, create a new user on chain and return the new address; mark this as a new user
-        return contracts.createUser({ id: username }).then((address) => {
+        return contracts.createUser({ id: crypto.createHash('sha256').update(username).digest('hex') }).then((address) => {
           return { id, address, newUser: true }
         })
       }

--- a/api/sqlsol/ParticipantsManager.json
+++ b/api/sqlsol/ParticipantsManager.json
@@ -1,6 +1,5 @@
 {
   "initSeq":{
-    "userAccount":{"deserialize":"getUserAccountAtIndex", "len":{"call": "getUserAccountsSize", "field": "size"}},
     "organization":{"deserialize":"getOrganizationAtIndex", "len":{"call": "getNumberOfOrganizations", "field": "size"}},
     "approverKey": {"dependent": "organization", "deserialize":"getApproverAtIndex", "len":{"call": "getNumberOfApprovers", "field": "size"}},
     "userKey": {"dependent": "organization", "deserialize":"getUserAtIndex", "len":{"call": "getNumberOfUsers", "field": "size"}},
@@ -8,10 +7,6 @@
     "departmentUserKey": {"dependent": "departmentKey", "deserialize":"getDepartmentUserAtIndex", "len":{"call": "getNumberOfDepartmentUsers", "field": "size"}}
   },
   "tables":{
-    "USERS":{
-      "call": "getUserAccountData",
-      "keys": ["userAccount"]
-    },
     "ORGANIZATIONS":{
       "call": "getOrganizationData",
       "keys": ["organization"]

--- a/api/test/api/web-api-bpm-test.js
+++ b/api/test/api/web-api-bpm-test.js
@@ -6,6 +6,7 @@ const rid = require('random-id');
 const path = require('path');
 const fs = require('fs');
 const _ = require('lodash');
+const crypto = require('crypto');
 
 const app = require('../../app')();
 const server = require(__common + '/aa-web-api')();
@@ -1593,8 +1594,8 @@ describe(':: External Users ::', () => {
     // CHECK USER CREATION
     setTimeout(async () => {
       try {
-        const user1 = await contracts.getUserById(externalUser1.email.toLowerCase());
-        const user2 = await contracts.getUserById(externalUser2.email.toLowerCase());
+        const user1 = await contracts.getUserById(crypto.createHash('sha256').update(externalUser1.email.toLowerCase()).digest('hex'));
+        const user2 = await contracts.getUserById(crypto.createHash('sha256').update(externalUser2.email.toLowerCase()).digest('hex'));
         expect(user1).to.be.a('object');
         expect(user2).to.be.a('object');
         expect(/[0-9A-Fa-f]{40}/.test(user1.address)).to.be.true;
@@ -1612,7 +1613,7 @@ describe(':: External Users ::', () => {
     // CHECK USER CREATION
     setTimeout(async () => {
       try {
-        await assert.isRejected(contracts.getUserById(externalUser1.email.toUpperCase()));
+        await assert.isRejected(contracts.getUserById(crypto.createHash('sha256').update(externalUser1.email.toUpperCase()).digest('hex')));
         done();
       } catch (err) {
         done(err);

--- a/api/test/controllers/contracts-test.js
+++ b/api/test/controllers/contracts-test.js
@@ -12,6 +12,7 @@ const should = chai.should()
 const expect = chai.expect
 const assert = chai.assert
 const monax = require('@monax/burrow')
+const crypto = require('crypto');
 
 global.__appDir = path.resolve()
 global.__common = path.resolve(__appDir, 'common')
@@ -157,7 +158,7 @@ describe('CONTRACTS', () => {
 
   it('Should create a user', async () => {
     let user = { id: rid(16, 'aA0') }
-    let res = await contracts.createUser(user)
+    let res = await contracts.createUser({id: crypto.createHash('sha256').update(user.id).digest('hex')})
     res.should.match(/[0-9A-Fa-f]{40}/) // match for 20 byte hex
     pAccount.address = res
     arch.author = pAccount.address

--- a/api/test/controllers/form-exec-usertask-test.js
+++ b/api/test/controllers/form-exec-usertask-test.js
@@ -10,6 +10,7 @@ const expect = chai.expect
 const assert = chai.assert
 const _ = require('lodash')
 const monax = require('@monax/burrow')
+const crypto = require('crypto');
 
 global.__appDir = path.resolve()
 global.__common = path.resolve(__appDir, 'common')
@@ -155,8 +156,8 @@ describe('FORMATION - EXECUTION with 1 User Task each', () => {
   }
 
   it('Should create a buyer and a seller', async () => {
-    let resBuyer = await contracts.createUser(buyer)
-    let resSeller = await contracts.createUser(seller)
+    let resBuyer = await contracts.createUser({ id: crypto.createHash('sha256').update(buyer.id).digest('hex') });
+    let resSeller = await contracts.createUser({ id: crypto.createHash('sha256').update(seller.id).digest('hex') });
     resBuyer.should.match(/[0-9A-Fa-f]{40}/) // match for 20 byte hex
     resSeller.should.match(/[0-9A-Fa-f]{40}/) // match for 20 byte hex
     buyer.address = resBuyer

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -12,7 +12,7 @@ import "agreements/DefaultArchetype.sol";
 
 contract ActiveAgreementTest {
   
-  	string constant SUCCESS = "success";
+  string constant SUCCESS = "success";
 	string constant EMPTY_STRING = "";
 	bytes32 constant EMPTY = "";
 
@@ -41,8 +41,8 @@ contract ActiveAgreementTest {
 
 		address result;
 		ActiveAgreement agreement;
-		signer1 = new DefaultUserAccount("signer1", this, address(0));
-		signer2 = new DefaultUserAccount("signer2", this, address(0));
+		signer1 = new DefaultUserAccount(this, address(0));
+		signer2 = new DefaultUserAccount(this, address(0));
 
 		// set up the parties.
 		delete parties;
@@ -77,9 +77,9 @@ contract ActiveAgreementTest {
 	function testActiveAgreementSigning() external returns (string) {
 
 		bool success;
-	  	ActiveAgreement agreement;
-		signer1 = new DefaultUserAccount("signer1", this, address(0));
-		signer2 = new DefaultUserAccount("signer2", this, address(0));
+	  ActiveAgreement agreement;
+		signer1 = new DefaultUserAccount(this, address(0));
+		signer2 = new DefaultUserAccount(this, address(0));
 
 		// set up the parties.
 		// Signer1 is a direct signer
@@ -136,8 +136,8 @@ contract ActiveAgreementTest {
 		bool success;
 		ActiveAgreement agreement1;
 		ActiveAgreement agreement2;
-		signer1 = new DefaultUserAccount("signer1", this, address(0));
-		signer2 = new DefaultUserAccount("signer2", this, address(0));
+		signer1 = new DefaultUserAccount(this, address(0));
+		signer2 = new DefaultUserAccount(this, address(0));
 
 		// set up the parties.
 		delete parties;

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -173,10 +173,10 @@ contract ActiveAgreementWorkflowTest {
 		// ORGS/USERS
 		//
 		// create additional users via constructor
-		userAccount1 = new DefaultUserAccount(user1Id, this, address(0));
-		userAccount2 = new DefaultUserAccount(user2Id, this, address(0));
-		userAccount3 = new DefaultUserAccount(user3Id, this, address(0));
-		nonPartyAccount = new DefaultUserAccount("jane.doe", this, address(0));
+		userAccount1 = new DefaultUserAccount(this, address(0));
+		userAccount2 = new DefaultUserAccount(this, address(0));
+		userAccount3 = new DefaultUserAccount(this, address(0));
+		nonPartyAccount = new DefaultUserAccount(this, address(0));
 
 		org1 = new DefaultOrganization(approvers, EMPTY_STRING);
 		org2 = new DefaultOrganization(approvers, EMPTY_STRING);
@@ -324,8 +324,8 @@ contract ActiveAgreementWorkflowTest {
 		AbstractDbUpgradeable(agreementRegistry).acceptDatabase(registryDb);
 		agreementRegistry.setBpmService(bpmService);
 
-		userAccount1 = new DefaultUserAccount(user1Id, this, address(0));
-		userAccount2 = new DefaultUserAccount(user2Id, this, address(0));
+		userAccount1 = new DefaultUserAccount(this, address(0));
+		userAccount2 = new DefaultUserAccount(this, address(0));
 		delete parties;
 		parties.push(userAccount1);
 		parties.push(userAccount2);

--- a/contracts/src/bpm-runtime/test/BpmServiceTest.sol
+++ b/contracts/src/bpm-runtime/test/BpmServiceTest.sol
@@ -1238,8 +1238,8 @@ contract BpmServiceTest {
 
 		//TODO missing test coverage of the authorizePerformer function / completeActivity for users in different department settings
 
-		UserAccount user1 = new DefaultUserAccount("user1", this, 0x0);
-		UserAccount organizationUser = new DefaultUserAccount("TomHanks", this, 0x0);
+		UserAccount user1 = new DefaultUserAccount(this, 0x0);
+		UserAccount organizationUser = new DefaultUserAccount(this, 0x0);
 		DefaultOrganization org1 = new DefaultOrganization(emptyAddressArray, EMPTY_STRING);
 		if (!org1.addUserToDepartment(organizationUser, EMPTY)) return "Unable to add user account to organization default department";
 
@@ -1373,7 +1373,7 @@ contract BpmServiceTest {
 
 		TestBpmService service = getNewTestBpmService();
 
-		UserAccount user1 = new DefaultUserAccount("user1", this, 0x0);
+		UserAccount user1 = new DefaultUserAccount(this, 0x0);
 	
 		(error, addr) = repository.createProcessModel("testModelAbort", "Abort Test Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
@@ -1448,8 +1448,8 @@ contract BpmServiceTest {
 
 		bytes32 bytes32Value;
 
-		UserAccount user1 = new DefaultUserAccount(user1Id, this, 0x0);
-		UserAccount user2 = new DefaultUserAccount(user2Id, this, 0x0);
+		UserAccount user1 = new DefaultUserAccount(this, 0x0);
+		UserAccount user2 = new DefaultUserAccount(this, 0x0);
 
 		TestBpmService service = getNewTestBpmService();
 

--- a/contracts/src/commons-auth/DefaultEcosystem.sol
+++ b/contracts/src/commons-auth/DefaultEcosystem.sol
@@ -45,21 +45,27 @@ contract DefaultEcosystem is Ecosystem {
         external
     {
         ErrorsLib.revertIf(
+            (_id == ""), 
+            ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(),
+            "DefaultEcosystem.addUserAccount",
+            "User ID cannot be empty"
+        );
+        ErrorsLib.revertIf(
+            (_userAccount == 0x0), 
+            ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(),
+            "DefaultEcosystem.addUserAccount",
+            "User account address cannot be empty"
+        );
+        ErrorsLib.revertIf(
             userAccounts.exists(_id), 
             ErrorsLib.RESOURCE_ALREADY_EXISTS(),
             "DefaultEcosystem.addUserAccount",
             "User with same ID already exists in given ecosystem"
         );
-        ErrorsLib.revertIf(
-            (_id == "" || _userAccount == 0x0), 
-            ErrorsLib.RESOURCE_ALREADY_EXISTS(),
-            "DefaultEcosystem.addUserAccount",
-            "User ID and account address both are required fields"
-        );
         uint error = userAccounts.insert(_id, _userAccount);
         ErrorsLib.revertIf(
             error != BaseErrors.NO_ERROR(), 
-            ErrorsLib.RESOURCE_ALREADY_EXISTS(),
+            ErrorsLib.RUNTIME_ERROR(),
             "DefaultEcosystem.addUserAccount",
             "User with same ID already exists in given ecosystem"
         );

--- a/contracts/src/commons-auth/DefaultEcosystem.sol
+++ b/contracts/src/commons-auth/DefaultEcosystem.sol
@@ -1,6 +1,9 @@
 pragma solidity ^0.4.23;
 
+import "commons-base/ErrorsLib.sol";
 import "commons-auth/Ecosystem.sol";
+import "commons-collections/Mappings.sol";
+import "commons-collections/MappingsLib.sol";
 
 /**
  * @title DefaultEcosystem
@@ -8,7 +11,10 @@ import "commons-auth/Ecosystem.sol";
  */
 contract DefaultEcosystem is Ecosystem {
 
+    using MappingsLib for Mappings.Bytes32AddressMap;
+    
     mapping (address => bool) publicKeys;
+    Mappings.Bytes32AddressMap userAccounts;
 
     constructor() public {
         owner = msg.sender;
@@ -33,5 +39,37 @@ contract DefaultEcosystem is Ecosystem {
         returns (bool)
     {
         return publicKeys[_address];
+    }
+
+    function addUserAccount(bytes32 _id, address _userAccount) 
+        external
+    {
+        ErrorsLib.revertIf(
+            userAccounts.exists(_id), 
+            ErrorsLib.RESOURCE_ALREADY_EXISTS(),
+            "DefaultEcosystem.addUserAccount",
+            "User with same ID already exists in given ecosystem"
+        );
+        ErrorsLib.revertIf(
+            (_id == "" || _userAccount == 0x0), 
+            ErrorsLib.RESOURCE_ALREADY_EXISTS(),
+            "DefaultEcosystem.addUserAccount",
+            "User ID and account address both are required fields"
+        );
+        uint error = userAccounts.insert(_id, _userAccount);
+        ErrorsLib.revertIf(
+            error != BaseErrors.NO_ERROR(), 
+            ErrorsLib.RESOURCE_ALREADY_EXISTS(),
+            "DefaultEcosystem.addUserAccount",
+            "User with same ID already exists in given ecosystem"
+        );
+    }
+
+    function getUserAccount(bytes32 _id)
+        external
+        view
+        returns (address _account) 
+    {
+        return userAccounts.get(_id);
     }
 }

--- a/contracts/src/commons-auth/DefaultParticipantsManager.sol
+++ b/contracts/src/commons-auth/DefaultParticipantsManager.sol
@@ -5,6 +5,7 @@ import "commons-base/BaseErrors.sol";
 import "commons-events/AbstractEventListener.sol";
 import "commons-management/AbstractDbUpgradeable.sol";
 
+import "commons-auth/Ecosystem.sol";
 import "commons-auth/ParticipantsManager.sol";
 import "commons-auth/ParticipantsManagerDb.sol";
 import "commons-auth/UserAccount.sol";
@@ -27,7 +28,6 @@ contract DefaultParticipantsManager is Versioned(1,0,0), AbstractEventListener, 
     bytes32 constant EVENT_REMOVE_DEPARTMENT_USER = "RemoveDepartmentUser";
 
     // SQLSOL metadata
-    string constant TABLE_USERS = "USERS";
     string constant TABLE_ORGANIZATIONS = "ORGANIZATIONS";
     string constant TABLE_ORGANIZATION_USERS = "ORGANIZATION_USERS";
     string constant TABLE_ORGANIZATION_APPROVERS = "ORGANIZATION_APPROVERS";
@@ -44,46 +44,90 @@ contract DefaultParticipantsManager is Versioned(1,0,0), AbstractEventListener, 
     function createUserAccount(bytes32 _id, address _owner, address _ecosystem) external returns (address userAccount) {
         ErrorsLib.revertIf(_id == "",
             ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultParticipantsManager.createUserAccount", "User ID must not be empty");
-        bytes32 hashedId = keccak256(abi.encodePacked(_id)); //TODO the ID should be hashed client-side and not here
-        ErrorsLib.revertIf(ParticipantsManagerDb(database).userAccountExists(hashedId),
-            ErrorsLib.OVERWRITE_NOT_ALLOWED(), "DefaultParticipantsManager.createUserAccount", "User with same ID already exists");
-        userAccount = new DefaultUserAccount(_id, _owner, _ecosystem); // passing user-readable id since DefaultUserAccount hashes it before storing
-        require(addUserAccount(userAccount) == BaseErrors.NO_ERROR(),
+        ErrorsLib.revertIf(Ecosystem(_ecosystem).getUserAccount(_id) != 0x0,
+            ErrorsLib.RESOURCE_ALREADY_EXISTS(), "DefaultParticipantsManager.createUserAccount", "User with same ID already exists in given ecosystem");
+        userAccount = new DefaultUserAccount(_owner, _ecosystem);
+        require(addUserAccount(_id, userAccount, _ecosystem) == BaseErrors.NO_ERROR(),
             ErrorsLib.format(ErrorsLib.INVALID_STATE(), "DefaultParticipantsManager.createUserAccount", "Unable to add new UserAccount to DB"));
     }
 
     /**
-     * @dev Adds the specified UserAccount.
+     * @dev Adds the specified UserAccount to the ParticipantsManagerDb as well as registers it to the given ecosystem
+     * @param _id user id
+     * @param _account user account address
+     * @param _ecosystem ecosystem address
      * @return NO_ERROR, RESOURCE_ALREADY_EXISTS if the user account ID is already registered
      */
-    function addUserAccount(address _account) public returns (uint error) {
-        error = ParticipantsManagerDb(database).addUserAccount(UserAccount(_account).getId(), _account);
+    function addUserAccount(bytes32 _id, address _account, address _ecosystem) public returns (uint error) {
+        error = ParticipantsManagerDb(database).addUserAccount(_account);
         if (error == BaseErrors.NO_ERROR()) {
-            emit UpdateUserAccount(TABLE_USERS, _account);
+            Ecosystem(_ecosystem).addUserAccount(_id, _account);
             emit LogUserCreation(
                 EVENT_ID_USER_ACCOUNTS,
                 _account,
-                UserAccount(_account).getId(),
+                _id,
                 UserAccount(_account).getOwner()
             );
         }
     }
 
     /**
-     * @dev Indicates whether the specified user account exists for the given userAccount ID
-     * @param _id userAccount ID
+     * @dev Indicates whether the specified user account exists for the given userAccount address
+     * @param _userAccount user account address
      * @return bool exists
      */
-    function userAccountExists(bytes32 _id) external view returns (bool) {
-        return ParticipantsManagerDb(database).userAccountExists(keccak256(abi.encodePacked(_id)));
+    function userAccountExists(address _userAccount) external view returns (bool) {
+        return ParticipantsManagerDb(database).userAccountExists(_userAccount);
     }
 
-	/**
-	 * @dev Returns the user account address for the specified user account ID.
-	 */
-    function getUserAccount(bytes32 _id) external view returns (uint, address) {
-        bytes32 hashedId = keccak256(abi.encodePacked(_id)); // hashing the user-readable id before lookup
-        return ParticipantsManagerDb(database).getUserAccount(hashedId);
+    /**
+     * @dev Indicates whether the specified user id and account address pair exists for the given ecosystem
+     * @param _userAccount user account address
+     * @param _id user account id
+     * @param _ecosystem ecosystem address
+     * @return bool exists
+     */
+    function userAccountExistsInEcosystem(bytes32 _id, address _userAccount, address _ecosystem)
+        external
+        view
+        returns (bool)
+    {
+        ErrorsLib.revertIf(
+            (_id == "" || _userAccount == 0x0 || _ecosystem == 0x0), 
+            ErrorsLib.INVALID_INPUT(),
+            "DefaultParticipantManager.userAccountExistsInEcosystem",
+            "User ID, account address and ecosystem address are all required fields"
+        );
+        ErrorsLib.revertIf(
+            !ParticipantsManagerDb(database).userAccountExists(_userAccount), 
+            ErrorsLib.RESOURCE_NOT_FOUND(),
+            "DefaultParticipantManager.userAccountExistsInEcosystem",
+            "User account with given address does not exist"
+        );
+        return Ecosystem(_ecosystem).getUserAccount(_id) == _userAccount;
+    }
+
+    /**
+     * @dev Gets user account address for the specified user account ID and ecosystem.
+     * @param _id the user account ID
+     * @param _ecosystem the ecosystem address
+     * @return addr user account address
+     */
+    function getUserAccount(bytes32 _id, address _ecosystem) external view returns (address) {
+        ErrorsLib.revertIf(
+            (_id == "" || _ecosystem == 0x0), 
+            ErrorsLib.INVALID_INPUT(),
+            "DefaultParticipantManager.getUserAccount",
+            "User ID and ecosystem address both are required fields"
+        );
+        address addr = Ecosystem(_ecosystem).getUserAccount(_id);
+        ErrorsLib.revertIf(
+            (addr == 0x0 || !ParticipantsManagerDb(database).userAccountExists(addr)), 
+            ErrorsLib.RESOURCE_NOT_FOUND(),
+            "DefaultParticipantManager.getUserAccount",
+            "No user account found with given user ID and ecosystem address"
+        );
+        return addr;
     }
 
     /**
@@ -291,41 +335,6 @@ contract DefaultParticipantsManager is Versioned(1,0,0), AbstractEventListener, 
      */
     function getUserAccountsSize() external view returns (uint size) {
         size = ParticipantsManagerDb(database).getNumberOfUserAccounts();
-    }
-
-    /**
-     * @dev Gets data for the specified user account.
-     * @param _userAccount the user account address
-     * @return id user account ID
-     * @return owner user account owner
-     */
-    function getUserAccountData(address _userAccount) external view returns (bytes32 id, address owner) {
-        UserAccount acc = UserAccount(_userAccount);
-        id = acc.getId();
-        owner = acc.getOwner();
-    }
-
-    /**
-     * @dev Gets hashed user account ID and user account address for the specified user account ID.
-     * @param _id the user account ID
-     * @return error RESOURCE_NOT_FOUND or NO_ERROR
-     * @return addr user account address
-     * @return hashedId hashed user account ID
-     */
-    function getUserAccountDataById(bytes32 _id) external view returns (uint error, address addr, bytes32 hashedId) {
-        hashedId = keccak256(abi.encodePacked(_id)); // hashing the user-readable id before lookup
-        (error, addr) = ParticipantsManagerDb(database).getUserAccount(hashedId);
-        if (error != BaseErrors.NO_ERROR()) return (error, 0x0, "");
-        error = BaseErrors.NO_ERROR();
-    }
-
-    /**
-     * @dev Gets user account at the given position.
-     * @param _pos position
-     * @return userAccount user account address
-     */
-    function getUserAccountAtIndex(uint _pos) external view returns (address) {
-        return ParticipantsManagerDb(database).getUserAccountAtIndex(_pos);
     }
 
 	/**

--- a/contracts/src/commons-auth/DefaultUserAccount.sol
+++ b/contracts/src/commons-auth/DefaultUserAccount.sol
@@ -38,20 +38,16 @@ contract DefaultUserAccount is UserAccount {
     }
 
     /**
-     * @dev Creates a new UserAccount with the given ID and belonging to the specified owner and/or ecosystem.
+     * @dev Creates a new UserAccount belonging to the specified owner and/or ecosystem.
      * One or both owner/ecosystem are required to be set to guarantee another entity has control over this UserAccount
      * REVERTS if:
      * - both owner and ecosystem are empty.
-     * @param _id id (required)
      * @param _owner public external address of individual owner (optional)
      * @param _ecosystem address of an ecosystem (optional)
      */
-    constructor(bytes32 _id, address _owner, address _ecosystem) public {
-        ErrorsLib.revertIf(_id == "",
-            ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultUserAccount.constructor", "ID must not be NULL");
+    constructor(address _owner, address _ecosystem) public {
         ErrorsLib.revertIf(_owner == address(0) && _ecosystem == address(0),
             ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultUserAccount.constructor", "One of owner or ecosystem must be provided");
-        account.id = keccak256(abi.encodePacked(_id)); // Hashing userId before storing //TODO the ID should be hashed before passing it in a transaction. check in API
         owner = _owner;
         if (_ecosystem != address(0)) {
             account.ecosystems.insertOrUpdate(_ecosystem, true);
@@ -91,13 +87,4 @@ contract DefaultUserAccount is UserAccount {
             }
         }
     }
-
-	/**
-	 * @dev Returns this account's ID
-     * @return the account ID
-	 */
-    function getId() public view returns (bytes32) {
-        return account.id;
-    }
-    
 }

--- a/contracts/src/commons-auth/Ecosystem.sol
+++ b/contracts/src/commons-auth/Ecosystem.sol
@@ -13,5 +13,9 @@ contract Ecosystem is Owned {
     function removeExternalAddress(address _address) external;
 
     function isKnownExternalAddress(address _address) external view returns (bool);
+    
+    function addUserAccount(bytes32 _id, address _userAccount) external;
+
+    function getUserAccount(bytes32 _id) external view returns (address _account);
 
 }

--- a/contracts/src/commons-auth/Governance.sol
+++ b/contracts/src/commons-auth/Governance.sol
@@ -28,7 +28,6 @@ library Governance {
     }
 
     struct UserAccount {
-        bytes32 id;
         Mappings.AddressBoolMap ecosystems;
         bool exists;
     }

--- a/contracts/src/commons-auth/ParticipantsManager.sol
+++ b/contracts/src/commons-auth/ParticipantsManager.sol
@@ -91,23 +91,13 @@ contract ParticipantsManager is EventListener, Upgradeable {
     bytes32 public constant EVENT_ID_DEPARTMENT_USERS = "AN://departments/users";
 
     /**
-    * @dev Creates and adds a user account
-    * @param _id id (required)
-    * @param _owner owner (optional)
-    * @param _ecosystem owner (optional)
-    * @return error code indicating success or failure
-    * @return userAccount user account
-    */
-    function createUserAccount(bytes32 _id, address _owner, address _ecosystem) external returns (address userAccount);
-
-    /**
-     * @dev Adds the specified UserAccount to the ParticipantsManagerDb as well as registers it to the given ecosystem
-     * @param _id user id
-     * @param _account user account address
-     * @param _ecosystem ecosystem address
-     * @return NO_ERROR, RESOURCE_ALREADY_EXISTS if the user account ID is already registered
+     * @dev Creates and adds a user account, and optionally registers the user with an ecosystem if an address is provided
+     * @param _id id (required)
+     * @param _owner owner (optional)
+     * @param _ecosystem owner (optional)
+     * @return userAccount user account
      */
-    function addUserAccount(bytes32 _id, address _account, address _ecosystem) public returns (uint);
+    function createUserAccount(bytes32 _id, address _owner, address _ecosystem) external returns (address userAccount);
 
 	/**
 	 * @dev Adds the organization at the specified address

--- a/contracts/src/commons-auth/ParticipantsManager.sol
+++ b/contracts/src/commons-auth/ParticipantsManager.sol
@@ -101,10 +101,13 @@ contract ParticipantsManager is EventListener, Upgradeable {
     function createUserAccount(bytes32 _id, address _owner, address _ecosystem) external returns (address userAccount);
 
     /**
-     * @dev Adds the specified UserAccount
-     * @return an error code
+     * @dev Adds the specified UserAccount to the ParticipantsManagerDb as well as registers it to the given ecosystem
+     * @param _id user id
+     * @param _account user account address
+     * @param _ecosystem ecosystem address
+     * @return NO_ERROR, RESOURCE_ALREADY_EXISTS if the user account ID is already registered
      */
-    function addUserAccount(address _account) public returns (uint);
+    function addUserAccount(bytes32 _id, address _account, address _ecosystem) public returns (uint);
 
 	/**
 	 * @dev Adds the organization at the specified address
@@ -216,32 +219,31 @@ contract ParticipantsManager is EventListener, Upgradeable {
 
     /**
      * @dev Indicates whether the specified user account exists for the given userAccount ID
-     * @param _id userAccount ID
+     * @param _userAccount user account address
      * @return bool exists
      */
-    function userAccountExists(bytes32 _id) external view returns (bool);
+    function userAccountExists(address _userAccount) external view returns (bool);
 
     /**
-     * @dev Returns the user account address for the specified user account ID.
+     * @dev Indicates whether the specified user id and account address pair exists for the given ecosystem
+     * @param _userAccount user account address
+     * @param _id user account id
+     * @param _ecosystem ecosystem address
+     * @return bool exists
      */
-    function getUserAccount(bytes32 _id) external view returns (uint, address);
+    function userAccountExistsInEcosystem(bytes32 _id, address _userAccount, address _ecosystem) external view returns (bool);
+
+    /**
+     * @dev Gets user account address for the specified user account ID and ecosystem.
+     * @param _id the user account ID
+     * @param _ecosystem the ecosystem address
+     * @return addr user account address
+     */
+    function getUserAccount(bytes32 _id, address _ecosystem) external view returns (address);
 
     /**
      * SQLSOL support functions
      */
 
     function getUserAccountsSize() external view returns (uint size);
-
-    function getUserAccountData(address _userAccount) external view returns (bytes32 id, address owner);
-
-    /**
-     * @dev Gets hashed user account ID and user account address for the specified user account ID.
-     * @param _id the user account ID
-     * @return error RESOURCE_NOT_FOUND or NO_ERROR
-     * @return addr user account address
-     * @return hashedId hashed user account ID
-     */
-    function getUserAccountDataById(bytes32 _id) external view returns (uint error, address addr, bytes32 hashedId);
-
-    function getUserAccountAtIndex(uint _pos) external view returns (address userAccount);
 }

--- a/contracts/src/commons-auth/ParticipantsManagerDb.sol
+++ b/contracts/src/commons-auth/ParticipantsManagerDb.sol
@@ -12,10 +12,9 @@ import "commons-collections/MappingsLib.sol";
  */
 contract ParticipantsManagerDb is SystemOwned {
   
-  using MappingsLib for Mappings.Bytes32AddressMap;
   using MappingsLib for Mappings.AddressBoolMap;
 
-  Mappings.Bytes32AddressMap userAccounts;
+  Mappings.AddressBoolMap userAccounts;
   Mappings.AddressBoolMap organizations;
 
   /**
@@ -25,27 +24,24 @@ contract ParticipantsManagerDb is SystemOwned {
     systemOwner = msg.sender;
   }
  
-  function addUserAccount(bytes32 _id, address _account) external pre_onlyBySystemOwner returns (uint error) {
-    error = userAccounts.insert(_id, _account);
+  function addUserAccount(address _account) external pre_onlyBySystemOwner returns (uint error) {
+    error = userAccounts.insert(_account, true);
   }
 
-  function userAccountExists(bytes32 _id) external view returns (bool) {
-    return userAccounts.exists(_id);
+  function userAccountExists(address _account) external view returns (bool) {
+    return userAccounts.exists(_account);
   }
 
   function getNumberOfUserAccounts() external view returns (uint) {
     return userAccounts.keys.length;
   }
 
-  function getUserAccount(bytes32 _id) external view returns (uint, address) {
-    if (!userAccounts.exists(_id)) return (BaseErrors.RESOURCE_NOT_FOUND(), 0x0);
-    return (BaseErrors.NO_ERROR(), userAccounts.get(_id));
+  function getUserAccount(address _account) external view returns (bool) {
+    return userAccounts.get(_account);
   }
 
-  function getUserAccountAtIndex(uint _index) external view returns (address userAccount) {
-    uint error;
-    uint next;
-    (error, userAccount, next) = userAccounts.valueAtIndexHasNext(_index);
+  function getUserAccountAtIndex(uint _index) external view returns (address) {
+    ( , address account) = userAccounts.keyAtIndex(_index);
   }
 
   function addOrganization(address _address) external pre_onlyBySystemOwner returns (uint error) {

--- a/contracts/src/commons-auth/ParticipantsManagerDb.sol
+++ b/contracts/src/commons-auth/ParticipantsManagerDb.sol
@@ -42,6 +42,7 @@ contract ParticipantsManagerDb is SystemOwned {
 
   function getUserAccountAtIndex(uint _index) external view returns (address) {
     ( , address account) = userAccounts.keyAtIndex(_index);
+    return account;
   }
 
   function addOrganization(address _address) external pre_onlyBySystemOwner returns (uint error) {

--- a/contracts/src/commons-auth/UserAccount.sol
+++ b/contracts/src/commons-auth/UserAccount.sol
@@ -1,13 +1,12 @@
 pragma solidity ^0.4.23;
 
 import "commons-base/Owned.sol";
-import "commons-base/Bytes32Identifiable.sol";
 
 /**
  * @title UserAccount Interface
  * @dev API for interacting with a user account
  */
-contract UserAccount is Owned, Bytes32Identifiable {
+contract UserAccount is Owned {
 
     /**
      * @dev Forwards a call to the specified target using the given bytes message.

--- a/contracts/src/commons-auth/test/ParticipantsManagerTest.sol
+++ b/contracts/src/commons-auth/test/ParticipantsManagerTest.sol
@@ -85,15 +85,19 @@ contract ParticipantsManagerTest {
         DefaultOrganization org1 = new DefaultOrganization(approvers, EMPTY_STRING);
         DefaultOrganization org2 = new DefaultOrganization(approvers, EMPTY_STRING);
 
-        UserAccount account1 = new DefaultUserAccount(participantsManager, 0x0);
-        UserAccount account2 = new DefaultUserAccount(participantsManager, 0x0);
-        address account3;
         uint oldSize = participantsManager.getUserAccountsSize();
+
+        address account1 = participantsManager.createUserAccount(acc1Id, 0x0, myEcosystem);
+        address account2 = participantsManager.createUserAccount(acc2Id, 0x0, myEcosystem);
+
+        if (participantsManager.getUserAccountsSize() != oldSize + 2) return "Expected accounts size to be +2";
+
+        address account3;
         uint departmentUserSize;
 
-        if (BaseErrors.NO_ERROR() != participantsManager.addUserAccount(acc1Id, account1, myEcosystem)) return "Error adding account1.";
-        if (BaseErrors.NO_ERROR() != participantsManager.addUserAccount(acc2Id, account2, myEcosystem)) return "Error adding account2.";
-        if (BaseErrors.RESOURCE_ALREADY_EXISTS() != participantsManager.addUserAccount(acc2Id, account2, myEcosystem)) return "Expected error for existing account2.";
+        if (address(participantsManager).call(bytes4(keccak256(abi.encodePacked("createUserAccount(bytes32,address,address)"))), acc2Id, 0x0, myEcosystem)) {
+            return "Expected error when creating new account with existing user id in same ecosystem.";
+        }
 
         // test adding users
         if (participantsManager.getUserAccountsSize() != oldSize + 2) return "Expected accounts size to be +2";
@@ -270,9 +274,6 @@ contract ParticipantsManagerTest {
 		address[] memory emptyAdmins;
 
         Organization org = new DefaultOrganization(emptyAdmins, EMPTY_STRING);
-        bytes32 user1Id = "user1";
-        bytes32 user2Id = "user2";
-        bytes32 user3Id = "user3";
         bytes32 dep1Id = "department";
 
         UserAccount user1 = new DefaultUserAccount(participantsManager, 0x0);

--- a/contracts/src/commons-auth/test/ParticipantsManagerTest.sol
+++ b/contracts/src/commons-auth/test/ParticipantsManagerTest.sol
@@ -22,9 +22,14 @@ contract ParticipantsManagerTest {
     bytes32 id;
     
     ParticipantsManager participantsManager;
+    Ecosystem myEcosystem;
 
     bytes32 EMPTY = "";
     string constant EMPTY_STRING = "";
+
+    bytes32 acc1Id;
+    bytes32 acc2Id;
+    bytes32 acc3Id;
 
     /**
      * @dev Internal helper function to initiate a new ParticipantsManager with an empty database.
@@ -44,10 +49,11 @@ contract ParticipantsManagerTest {
         ExternalCaller ownerCaller = new ExternalCaller();
         ExternalCaller ecosystemCaller = new ExternalCaller();
 
-        Ecosystem myEcosystem = new DefaultEcosystem();
+        myEcosystem = new DefaultEcosystem();
         myEcosystem.addExternalAddress(address(ecosystemCaller));
 
-        TestUserAccount user1 = new TestUserAccount("user1", address(ownerCaller), address(myEcosystem));
+        TestUserAccount user1 = new TestUserAccount(address(ownerCaller), address(myEcosystem));
+        myEcosystem.addUserAccount("user1", user1);
 
         // first test failure
         if (address(user1).call(bytes4(keccak256(abi.encodePacked("authorizedCall()")))))
@@ -66,9 +72,9 @@ contract ParticipantsManagerTest {
         participantsManager = createNewParticipantsManager();
 
         // generate unique names for this test
-        bytes32 acc1Id = TypeUtilsAPI.toBytes32(block.number+34);
-        bytes32 acc2Id = "dummyId";
-        bytes32 acc3Id = "dummyId2";
+        acc1Id = TypeUtilsAPI.toBytes32(block.number+34);
+        acc2Id = "dummyId";
+        acc3Id = "dummyId2";
         bytes32 dep1Id = "dep1Id";
         string memory dep1Name = "dep1Name";
         bytes32 dep2Id = "dep2Id";
@@ -79,15 +85,15 @@ contract ParticipantsManagerTest {
         DefaultOrganization org1 = new DefaultOrganization(approvers, EMPTY_STRING);
         DefaultOrganization org2 = new DefaultOrganization(approvers, EMPTY_STRING);
 
-        UserAccount account1 = new DefaultUserAccount(acc1Id, participantsManager, 0x0);
-        UserAccount account2 = new DefaultUserAccount(acc2Id, participantsManager, 0x0);
+        UserAccount account1 = new DefaultUserAccount(participantsManager, 0x0);
+        UserAccount account2 = new DefaultUserAccount(participantsManager, 0x0);
         address account3;
         uint oldSize = participantsManager.getUserAccountsSize();
         uint departmentUserSize;
 
-        if (BaseErrors.NO_ERROR() != participantsManager.addUserAccount(account1)) return "Error adding account1.";
-        if (BaseErrors.NO_ERROR() != participantsManager.addUserAccount(account2)) return "Error adding account2.";
-        if (BaseErrors.RESOURCE_ALREADY_EXISTS() != participantsManager.addUserAccount(account2)) return "Expected error for existing account2.";
+        if (BaseErrors.NO_ERROR() != participantsManager.addUserAccount(acc1Id, account1, myEcosystem)) return "Error adding account1.";
+        if (BaseErrors.NO_ERROR() != participantsManager.addUserAccount(acc2Id, account2, myEcosystem)) return "Error adding account2.";
+        if (BaseErrors.RESOURCE_ALREADY_EXISTS() != participantsManager.addUserAccount(acc2Id, account2, myEcosystem)) return "Expected error for existing account2.";
 
         // test adding users
         if (participantsManager.getUserAccountsSize() != oldSize + 2) return "Expected accounts size to be +2";
@@ -96,20 +102,15 @@ contract ParticipantsManagerTest {
         oldSize = participantsManager.getUserAccountsSize();
 
         // test creating user accounts via ParticipantsManager
-        account3 = participantsManager.createUserAccount(acc3Id, this, 0x0);
+        account3 = participantsManager.createUserAccount(acc3Id, this, myEcosystem);
 
-        if (UserAccount(account3).getId() != keccak256(abi.encodePacked(acc3Id))) return "UserAccount account3 id mismatch";
-        (error, addr) = participantsManager.getUserAccount(acc3Id);
-        if (addr != account3) return "account3 address mismatch";
-        if (error != BaseErrors.NO_ERROR()) return "Exp. NO_ERROR";
+        if (!participantsManager.userAccountExistsInEcosystem(acc3Id, account3, myEcosystem)) return "UserAccount account3 does not exist in myEcosystem";
+        addr = participantsManager.getUserAccount(acc3Id, myEcosystem);
         if (addr == 0x0) return "Exp. non-0x0 address";
-        if (UserAccount(addr).getId() != keccak256(abi.encodePacked(acc3Id))) return "UserAccount addr id mismatch";
+        if (addr != account3) return "account3 address mismatch";
+        // if (UserAccount(addr).getId() != keccak256(abi.encodePacked(acc3Id))) return "UserAccount addr id mismatch";
         if (UserAccount(addr).getOwner() != address(this)) return "Exp. this";
         if (participantsManager.getUserAccountsSize() != oldSize + 1) return "Expected accounts size to be +1";
-        (error, addr, id) = participantsManager.getUserAccountDataById(acc3Id);
-        if (error != BaseErrors.NO_ERROR()) return "Exp. NO_ERROR retrieving account data by id";
-        if (addr == 0x0) return "Exp. non-0x0 address retrieving account data by id";
-        if (id != keccak256(abi.encodePacked(acc3Id))) return "UserAccount account3 id mismatch retrieving account data by id";
 
         // test adding user accounts to organizations via Organization
         oldSize = org1.getNumberOfUsers();
@@ -167,16 +168,16 @@ contract ParticipantsManagerTest {
 
 		// reusable variables in this test
 		address[] memory emptyAdmins;
-        bytes32 acc1Id = TypeUtilsAPI.toBytes32(block.number+34);
-        bytes32 acc2Id = "dummyId";
+        acc1Id = TypeUtilsAPI.toBytes32(block.number+34);
+        acc2Id = "dummyId";
         bytes32 dep1Id = "dep1Id";
         string memory dep1Name = "Department 1 Name";
 		
 		// externally created organizations
 		Organization org1 = new DefaultOrganization(emptyAdmins, "Unassigned");
 
-        UserAccount user1 = new DefaultUserAccount(acc1Id, participantsManager, 0x0);
-        UserAccount user2 = new DefaultUserAccount(acc2Id, participantsManager, 0x0);
+        UserAccount user1 = new DefaultUserAccount(participantsManager, 0x0);
+        UserAccount user2 = new DefaultUserAccount(participantsManager, 0x0);
 		
         // Test special handling of the default department in the organization
         if (!org1.departmentExists(org1.DEFAULT_DEPARTMENT_ID()))
@@ -274,9 +275,9 @@ contract ParticipantsManagerTest {
         bytes32 user3Id = "user3";
         bytes32 dep1Id = "department";
 
-        UserAccount user1 = new DefaultUserAccount(user1Id, participantsManager, 0x0);
-        UserAccount user2 = new DefaultUserAccount(user2Id, participantsManager, 0x0);
-        UserAccount user3 = new DefaultUserAccount(user3Id, participantsManager, 0x0);
+        UserAccount user1 = new DefaultUserAccount(participantsManager, 0x0);
+        UserAccount user2 = new DefaultUserAccount(participantsManager, 0x0);
+        UserAccount user3 = new DefaultUserAccount(participantsManager, 0x0);
 
         // User1 -> default department
         // User2 -> Department 1
@@ -305,8 +306,8 @@ contract ParticipantsManagerTest {
 
 contract TestUserAccount is DefaultUserAccount {
 
-    constructor(bytes32 _id, address _owner, address _ecosystem) public
-        DefaultUserAccount(_id, _owner, _ecosystem) {
+    constructor(address _owner, address _ecosystem) public
+        DefaultUserAccount(_owner, _ecosystem) {
         
     }
 

--- a/contracts/src/commons-auth/test/UserAccountTest.sol
+++ b/contracts/src/commons-auth/test/UserAccountTest.sol
@@ -24,8 +24,8 @@ contract UserAccountTest {
 		TestService testService = new TestService();
 		bool success;
 
-		UserAccount account = new DefaultUserAccount("userId77", this, 0x0);
-		UserAccount externalAccount = new DefaultUserAccount("userId14", msg.sender, 0x0);
+		UserAccount account = new DefaultUserAccount(this, 0x0);
+		UserAccount externalAccount = new DefaultUserAccount(msg.sender, 0x0);
 
 		bytes memory payload = abi.encodeWithSignature(testServiceFunctionSig, address(this), testState, testKey);
 		// test failures

--- a/contracts/src/deploy-module-Ecosystem.yaml
+++ b/contracts/src/deploy-module-Ecosystem.yaml
@@ -45,7 +45,7 @@ jobs:
 - name: EcosystemRegistry
   deploy:
     contract: DefaultEcosystemRegistry.bin
-    libraries: ErrorsLib:$ErrorsLib
+    libraries: ErrorsLib:$ErrorsLib, MappingsLib:$MappingsLib
 
 - name: EcosystemRegistryDb
   deploy:


### PR DESCRIPTION
Changes:
- User ids are now SHA256 hashed in API layer before sending to chain
- Chain only stores hashed ids for privacy
- All auth functions hash user submitted ids before validating with chain
- UserIds are now stored in a Address-to-UserId hash in the Ecosystem contract
- To get user account address, the API must submit the UserId and ecosystem address where the Id is registered
- Username field in the postgres `users` table has been updated to varchar(255) for storing longer ids/emails

Signed-off-by: Sam Sinha <ssinha484@gmail.com>