### PR TITLE
Upgrade to Burrow 0.23.1 and give chain its own container and image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,47 +5,16 @@ defaults: &defaults
   environment:
     IMAGE_API: quay.io/monax/blackstone
 
-version: 2
+version: 2.1
 jobs:
-  test_contracts:
-    <<: *defaults
+  test:
+    machine:
+      enabled: true
     steps:
       - checkout
-      - run: burrow deploy --file build.yaml --dir ./contracts/src
-      - run: ./test/test_contracts.sh
-      - store_artifacts:
-          path: ./burrow.log
-      - store_artifacts:
-          path: ./test-contracts-jobs.log
-      - store_artifacts:
-          path: ./test-contracts.log
-  test_api:
-    docker:
-      - image: quay.io/monax/build:latest
-      - image: quay.io/monax/hoard:1.1.3
-        name: hoard
-      - image: postgres:9-alpine
-        name: postgres
-        environment:
-          POSTGRES_USER: blackstone_development
-          POSTGRES_PASSWORD: blackstone_development
-      - image:
-    working_directory: ~/blackstone
-    steps:
-      - checkout
-      - run:
-          name: Install npm
-          command: |
-            cd ./api/
-            npm install
-      - run:
-          name: Test API
-          command: ./test/test_api.sh
-          environment:
-            POSTGRES_USER: blackstone_development
-            POSTGRES_PASSWORD: blackstone_development
-      - store_artifacts:
-          path: ./burrow.log
+      - run: make install_api
+      - run: make test
+
   deploy_docs:
     <<: *defaults
     steps:
@@ -55,6 +24,7 @@ jobs:
           fingerprints:
             - "5e:f3:47:75:34:c7:83:93:51:48:31:6a:3a:1a:de:85"
       - run: ./docs/generate.sh
+
   deploy_platform:
     docker:
       - image: appropriate/curl
@@ -68,6 +38,7 @@ jobs:
               --form token=$PLATFORM_DEPLOY_KEY \
               --form ref=master \
               $PLATFORM_DEPLOY_URL
+
   update_info:
     docker:
       - image: alpine/git
@@ -110,8 +81,7 @@ workflows:
   version: 2
   test_and_deploy:
     jobs:
-      - test_contracts:
-      - test_api:
+      - test
       - deploy_docs:
           filters:
             branches:
@@ -119,8 +89,7 @@ workflows:
                 - master
       - update_info:
           requires:
-            - test_api
-            - test_contracts
+            - test
           filters:
             branches:
               only:
@@ -128,8 +97,7 @@ workflows:
                 - develop
       - deploy_platform:
           requires:
-            - test_api
-            - test_contracts
+            - test
             - update_info
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,56 +7,11 @@ defaults: &defaults
 
 version: 2
 jobs:
-  cache_contracts:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: burrow deploy --file build.yaml --dir ./contracts/src
-      - persist_to_workspace:
-          root: ./contracts/src/
-          paths:
-            - bin
-  cache_api:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - api-{{ checksum "api/package-lock.json" }}
-            - api
-      - run:
-          name: Install npm
-          command: |
-            cd ./api/
-            npm install
-      - save_cache:
-          key: api-{{ checksum "api/package-lock.json" }}
-          paths:
-            - api/node_modules/
-      - persist_to_workspace:
-          root: ./api/
-          paths:
-            - node_modules
-  build_vent:
-    docker:
-      - image: golang:1.10
-    working_directory: ~/blackstone
-    steps:
-      - checkout
-      - run: |
-          go get -u github.com/monax/bosmarmot/...
-          cd $GOPATH/src/github.com/monax/bosmarmot/vent
-          go build -o ~/bos/vent .
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - bos
   test_contracts:
     <<: *defaults
     steps:
       - checkout
-      - attach_workspace:
-          at: contracts/src
+      - run: burrow deploy --file build.yaml --dir ./contracts/src
       - run: ./test/test_contracts.sh
       - store_artifacts:
           path: ./burrow.log
@@ -74,15 +29,15 @@ jobs:
         environment:
           POSTGRES_USER: blackstone_development
           POSTGRES_PASSWORD: blackstone_development
+      - image:
     working_directory: ~/blackstone
     steps:
       - checkout
-      - attach_workspace:
-          at: /tmp
-      - run: |
-          mv /tmp/bos ./
-          mv /tmp/bin ./contracts/src/.
-          mv /tmp/node_modules ./api/.
+      - run:
+          name: Install npm
+          command: |
+            cd ./api/
+            npm install
       - run:
           name: Test API
           command: ./test/test_api.sh
@@ -155,17 +110,8 @@ workflows:
   version: 2
   test_and_deploy:
     jobs:
-      - cache_contracts
-      - cache_api
-      - build_vent
       - test_contracts:
-          requires:
-            - cache_contracts
       - test_api:
-          requires:
-            - cache_api
-            - cache_contracts
-            - build_vent
       - deploy_docs:
           filters:
             branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # For solc binary
 FROM ethereum/solc:0.4.25 as solc-builder
-# For burrow deploy - may need to synchronise with version used for chain service in docker-compose
-FROM hyperledger/burrow:0.23.1-dev-2018-11-14-f23fae1e as burrow-builder
+# Burrow version on which Blackstone is tested
+FROM hyperledger/burrow:0.23.1 as burrow-builder
 # Testing image
 FROM alpine:latest
+
 RUN apk --update --no-cache add \
   bash \
   coreutils \
@@ -22,14 +23,6 @@ RUN apk --update --no-cache add \
   tar
 
 ARG INSTALL_BASE=/usr/local/bin
-ARG USER=blackstone
-ARG UID=2000
-ARG GID=2001
 
 COPY --from=burrow-builder /usr/local/bin/burrow $INSTALL_BASE/
 COPY --from=solc-builder /usr/bin/solc $INSTALL_BASE/
-
-# Run as unprivileged user
-RUN echo aa addgroup -g $GID -S $USER adduser -S -D -u $UID $USER $USER
-RUN addgroup -g $GID -S $USER && adduser -S -D -u $UID $USER $USER
-USER $USER:$USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
+ARG SOLC_VERSION=0.4.25
+ARG BURROW_VERSION=0.23.1
+# This container provides the test environment from which the various test scripts
+# can be run
 # For solc binary
-FROM ethereum/solc:0.4.25 as solc-builder
+FROM ethereum/solc:$SOLC_VERSION as solc-builder
 # Burrow version on which Blackstone is tested
-FROM hyperledger/burrow:0.23.1 as burrow-builder
+FROM hyperledger/burrow:$BURROW_VERSION as burrow-builder
 # Testing image
 FROM alpine:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# For solc binary
+FROM ethereum/solc:0.4.25 as solc-builder
+# For burrow deploy - may need to synchronise with version used for chain service in docker-compose
+FROM hyperledger/burrow:0.23.1-dev-2018-11-14-f23fae1e as burrow-builder
+# Testing image
+FROM alpine:latest
+RUN apk --update --no-cache add \
+  bash \
+  coreutils \
+  curl \
+  git \
+  g++ \
+  jq \
+  libc6-compat \
+  make \
+  nodejs \
+  nodejs-npm \
+  openssh-client \
+  parallel \
+  python \
+  py-crcmod \
+  tar
+
+ARG INSTALL_BASE=/usr/local/bin
+ARG USER=blackstone
+ARG UID=2000
+ARG GID=2001
+
+COPY --from=burrow-builder /usr/local/bin/burrow $INSTALL_BASE/
+COPY --from=solc-builder /usr/bin/solc $INSTALL_BASE/
+
+# Run as unprivileged user
+RUN echo aa addgroup -g $GID -S $USER adduser -S -D -u $UID $USER $USER
+RUN addgroup -g $GID -S $USER && adduser -S -D -u $UID $USER $USER
+USER $USER:$USER

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,24 @@
 #
 .PHONY: build_contracts
 build_contracts:
-	docker-compose run --workdir=/app/contracts/src chain burrow deploy -f $(if $(tgt),build-$(tgt),build.yaml)
+	docker-compose run --workdir=/app/contracts/src api burrow deploy -f $(if $(tgt),build-$(tgt),build.yaml)
 
 .PHONY: test_contracts
 test_contracts: build_contracts
-	docker-compose run chain test/test_contracts.sh $(tgt)
+	docker-compose run api test/test_contracts.sh $(tgt)
 
 .PHONY: install_api
 install_api:
-	docker-compose run --workdir=/app/api chain npm install
+	docker-compose run --workdir=/app/api api npm install
 
 .PHONY: test_api
 test_api: clean
-	docker-compose run chain test/test_api.sh
+	docker-compose run api test/test_api.sh
 
 .PHONY: run
 run: clean
 	docker-compose up -d
-	docker-compose logs --follow chain &
+	docker-compose logs --follow api &
 
 .PHONY: run_all
 run_all: install_api run
@@ -34,7 +34,7 @@ run_all: install_api run
 .PHONY: restart_api
 restart_api:
 	pkill docker-compose || true
-	docker-compose exec chain test/restart_api.sh
+	docker-compose exec api test/restart_api.sh
 
 .PHONY: test
 test: test_contracts test_api clean
@@ -42,11 +42,11 @@ test: test_contracts test_api clean
 .PHONY: clean
 clean:
 	pkill docker-compose || true
-	docker-compose run --no-deps chain test/clean
+	docker-compose run --no-deps api test/clean
 	docker-compose rm --force --stop
 
 .PHONY: clean_all
 clean_all:
 	pkill docker-compose || true
-	docker-compose run --no-deps chain test/clean all
+	docker-compose run --no-deps api test/clean all
 	docker-compose rm --force --stop

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,9 @@ clean: down
 .PHONY: clean_all
 clean_all: down
 	docker-compose run --no-deps api test/clean all
+
+# Make sure we have fresh service images
+.PHONY: rebuild_docker
+rebuild_docker: clean
+	docker-compose pull
+	docker-compose build --no-cache

--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,19 @@ restart_api:
 	docker-compose exec api test/restart_api.sh
 
 .PHONY: test
-test: test_contracts test_api clean
+# Ordered execution
+test: | test_contracts test_api clean
+
+.PHONY: down
+down:
+	pkill docker-compose || true
+	docker-compose down
+	docker-compose rm --force --stop
 
 .PHONY: clean
-clean:
-	pkill docker-compose || true
+clean: down
 	docker-compose run --no-deps api test/clean
-	docker-compose rm --force --stop
 
 .PHONY: clean_all
-clean_all:
-	pkill docker-compose || true
+clean_all: down
 	docker-compose run --no-deps api test/clean all
-	docker-compose rm --force --stop

--- a/api/config/settings.toml
+++ b/api/config/settings.toml
@@ -11,7 +11,7 @@ analyticsID = "TEST"
 #upload_limit =        # default: '100mb'
 
 [monax.chain]
-host = "127.0.0.1"
+host = "chain"
 port = 10997
 
 [monax.accounts]

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/highlight": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       }
     },
     "@grpc/proto-loader": {
@@ -29,10 +29,10 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.3.0.tgz",
       "integrity": "sha512-9b8S/V+3W4Gv7G/JKSZ48zApgyYbfIR7mAC9XNnaSWme3zj57MIESu0ELzm9j5oxNIpFG8DgO00iJMIUZ5luqw==",
       "requires": {
-        "@types/lodash": "^4.14.104",
-        "@types/node": "^9.4.6",
-        "lodash": "^4.17.5",
-        "protobufjs": "^6.8.6"
+        "@types/lodash": "4.14.117",
+        "@types/node": "9.6.32",
+        "lodash": "4.17.11",
+        "protobufjs": "6.8.8"
       }
     },
     "@monax/burrow": {
@@ -40,14 +40,14 @@
       "resolved": "https://registry.npmjs.org/@monax/burrow/-/burrow-0.20.8.tgz",
       "integrity": "sha512-ucPwGrIMpkaLcFwT8M/ymmr6Dx276sm7bq+Sb9docBq316owQSz1fuk2UgF9TRilTv4/zc3NqHG+LKgiycKZLA==",
       "requires": {
-        "@grpc/proto-loader": "^0.3.0",
+        "@grpc/proto-loader": "0.3.0",
         "@nodeguy/generic": "3.0.0",
         "@nodeguy/type": "0.2.0",
         "bignumber.js": "github:debris/bignumber.js#94d7146671b9719e00a09c29b01a691bc85048c2",
         "crypto-js": "3.1.4",
         "g-functions": "0.3.0",
-        "grpc": "^1.12.2",
-        "protobufjs": "^6.8.6",
+        "grpc": "1.15.1",
+        "protobufjs": "6.8.8",
         "ramda": "0.23.0",
         "utf8": "2.1.2",
         "web3": "0.18.4"
@@ -63,8 +63,8 @@
       "resolved": "https://registry.npmjs.org/@nodeguy/type/-/type-0.2.0.tgz",
       "integrity": "sha1-17MJ1awIWFLGd0zYF3ojIbEuL94=",
       "requires": {
-        "@nodeguy/generic": "^2.0.0",
-        "fj-curry": "^1.0.0"
+        "@nodeguy/generic": "2.1.1",
+        "fj-curry": "1.0.0"
       },
       "dependencies": {
         "@nodeguy/generic": {
@@ -99,8 +99,8 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/inquire": "1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -133,9 +133,9 @@
       "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-6.3.0.tgz",
       "integrity": "sha512-fTy8vRpA9Whtf8ULQr/0vkSZaQvGQ97rY5N5PrevKRtugJMsJqFMKO0pwzEWeqITSg71aMMTj57QTgw3SjZvnQ==",
       "requires": {
-        "@sendgrid/helpers": "^6.3.0",
-        "@types/request": "^2.0.3",
-        "request": "^2.81.0"
+        "@sendgrid/helpers": "6.3.0",
+        "@types/request": "2.47.1",
+        "request": "2.88.0"
       }
     },
     "@sendgrid/helpers": {
@@ -143,8 +143,8 @@
       "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-6.3.0.tgz",
       "integrity": "sha512-uTFcmhCDFg/2Uhz+z/cLwyLHH0UsblG49hKwdR7nKbWsGKWv4js7W32FlPdXqy2C/plTJ20vcPLgKM1m3F/MjQ==",
       "requires": {
-        "chalk": "^2.0.1",
-        "deepmerge": "^2.1.1"
+        "chalk": "2.4.1",
+        "deepmerge": "2.1.1"
       }
     },
     "@sendgrid/mail": {
@@ -152,8 +152,8 @@
       "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.3.1.tgz",
       "integrity": "sha512-5zIeAV9iU+0hQkrOQ/D4RB2MfpK+lNbOortIfQdCh95aMDF/TRc9WB8FGNhmQrx9YMuJTms5eiBklF0Fi/dbVg==",
       "requires": {
-        "@sendgrid/client": "^6.3.0",
-        "@sendgrid/helpers": "^6.3.0"
+        "@sendgrid/client": "6.3.0",
+        "@sendgrid/helpers": "6.3.0"
       }
     },
     "@types/caseless": {
@@ -178,7 +178,7 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.32"
       }
     },
     "@types/lodash": {
@@ -201,10 +201,10 @@
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
       "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
-        "@types/caseless": "*",
-        "@types/form-data": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/caseless": "0.12.1",
+        "@types/form-data": "2.2.1",
+        "@types/node": "9.6.32",
+        "@types/tough-cookie": "2.3.3"
       }
     },
     "@types/superagent": {
@@ -213,8 +213,8 @@
       "integrity": "sha512-Dnh0Iw6NO55z1beXvlsvUrfk4cd9eL2nuTmUk+rAhSVCk10PGGFbqCCTwbau9D0d2W3DITiXl4z8VCqppGkMPQ==",
       "dev": true,
       "requires": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
+        "@types/cookiejar": "2.1.0",
+        "@types/node": "9.6.32"
       }
     },
     "@types/tough-cookie": {
@@ -232,7 +232,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.20",
         "negotiator": "0.6.1"
       }
     },
@@ -248,7 +248,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.3"
+        "acorn": "5.7.3"
       }
     },
     "ajv": {
@@ -256,10 +256,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -284,7 +284,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "append-field": {
@@ -302,8 +302,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -312,7 +312,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-flatten": {
@@ -326,7 +326,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -346,8 +346,8 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
+        "colour": "0.7.1",
+        "optjs": "3.2.2"
       }
     },
     "asn1": {
@@ -355,7 +355,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -374,7 +374,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "asynckit": {
@@ -403,7 +403,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "bcryptjs": {
@@ -412,8 +412,7 @@
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "bignumber.js": {
-      "version": "github:debris/bignumber.js#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "from": "bignumber.js@github:debris/bignumber.js#94d7146671b9719e00a09c29b01a691bc85048c2"
+      "version": "github:debris/bignumber.js#94d7146671b9719e00a09c29b01a691bc85048c2"
     },
     "binstring": {
       "version": "0.2.1",
@@ -431,15 +430,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -462,7 +461,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
       "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.4"
       }
     },
     "bpmn-moddle": {
@@ -470,9 +469,9 @@
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-5.1.5.tgz",
       "integrity": "sha512-1f/1oTmnC1z14T69SQHdkBJZTM240ScPKCf39I1HX8Cg1dKaLSdWdhhlCtTJoGLn1eBpkLq/Pw5oE6FOlCAdsw==",
       "requires": {
-        "min-dash": "^3.0.0",
-        "moddle": "^4.1.0",
-        "moddle-xml": "^7.2.3"
+        "min-dash": "3.1.0",
+        "moddle": "4.1.0",
+        "moddle-xml": "7.2.3"
       }
     },
     "brace-expansion": {
@@ -480,7 +479,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -517,7 +516,7 @@
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
         "dicer": "0.2.5",
-        "readable-stream": "1.1.x"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -530,10 +529,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -548,7 +547,7 @@
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "requires": {
-        "long": "~3"
+        "long": "3.2.0"
       },
       "dependencies": {
         "long": {
@@ -569,7 +568,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -599,12 +598,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chai-as-promised": {
@@ -613,7 +612,7 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
-        "check-error": "^1.0.2"
+        "check-error": "1.0.2"
       }
     },
     "chai-http": {
@@ -622,13 +621,13 @@
       "integrity": "sha512-5j9LC1pl9jaPanux+wDm9D/V6R2xLfpixsRQhoJHxCR0E5KaiT0aL4544pVtYXN/wTUVSDTmwye5mCXkO/8b3w==",
       "dev": true,
       "requires": {
-        "@types/chai": "4",
-        "@types/superagent": "^3.8.3",
-        "cookiejar": "^2.1.1",
-        "is-ip": "^2.0.0",
-        "methods": "^1.1.2",
-        "qs": "^6.5.1",
-        "superagent": "^3.7.0"
+        "@types/chai": "4.1.5",
+        "@types/superagent": "3.8.4",
+        "cookiejar": "2.1.2",
+        "is-ip": "2.0.0",
+        "methods": "1.1.2",
+        "qs": "6.5.2",
+        "superagent": "3.8.3"
       }
     },
     "chalk": {
@@ -636,9 +635,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -669,7 +668,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -683,9 +682,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "co": {
@@ -726,7 +725,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "component-emitter": {
@@ -745,10 +744,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "console-control-strings": {
@@ -813,11 +812,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.5.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-js": {
@@ -830,9 +829,9 @@
       "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.8.tgz",
       "integrity": "sha512-DC6YFtsJiA7t/Yz+KjzT6GXuKtU/5gRbbl7HJqvDVVir+dxdw2/1EgwfgJdnsvUT7lOnON5DvGftKuYWX1nMOQ==",
       "requires": {
-        "bluebird": "^3.5.1",
-        "lodash": "^4.17.3",
-        "strip-bom": "^2.0.0"
+        "bluebird": "3.5.2",
+        "lodash": "4.17.11",
+        "strip-bom": "2.0.0"
       }
     },
     "cycle": {
@@ -845,7 +844,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "dasherize": {
@@ -863,22 +862,22 @@
       "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.11.3.tgz",
       "integrity": "sha512-xpfPu08sq9LWqA8v5dUpyqKbNPlFZYsKB1etVxuPE4krQotshD+dd/qaX4a+wv5mlFpGiIo8cDls8yQPrJL6Bw==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "bluebird": "^3.1.1",
-        "db-migrate-shared": "^1.2.0",
-        "deep-extend": "^0.5.1",
-        "dotenv": "^5.0.1",
-        "final-fs": "^1.6.0",
-        "inflection": "^1.10.0",
-        "mkdirp": "~0.5.0",
-        "optimist": "~0.6.1",
-        "parse-database-url": "~0.3.0",
-        "pkginfo": "^0.4.0",
-        "prompt": "^1.0.0",
-        "rc": "^1.2.8",
-        "resolve": "^1.1.6",
-        "semver": "^5.3.0",
-        "tunnel-ssh": "^4.0.0"
+        "balanced-match": "1.0.0",
+        "bluebird": "3.5.2",
+        "db-migrate-shared": "1.2.0",
+        "deep-extend": "0.5.1",
+        "dotenv": "5.0.1",
+        "final-fs": "1.6.1",
+        "inflection": "1.12.0",
+        "mkdirp": "0.5.1",
+        "optimist": "0.6.1",
+        "parse-database-url": "0.3.0",
+        "pkginfo": "0.4.1",
+        "prompt": "1.0.0",
+        "rc": "1.2.8",
+        "resolve": "1.8.1",
+        "semver": "5.5.1",
+        "tunnel-ssh": "4.1.4"
       }
     },
     "db-migrate-base": {
@@ -886,7 +885,7 @@
       "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-1.5.3.tgz",
       "integrity": "sha512-dbJHFVYIY75vSOL3MD4qbpjilcwrYn7ZnTqsdA2AGs6w1mYugspfWEBea+uMgJVH/YsUFxw2AYPKRHCHUjhirw==",
       "requires": {
-        "bluebird": "^3.1.1"
+        "bluebird": "3.5.2"
       }
     },
     "db-migrate-pg": {
@@ -894,10 +893,10 @@
       "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-0.4.0.tgz",
       "integrity": "sha512-N49I0qEh7e8fd852R3zD5ed+w2jyqTHsBkIULoTgafgTr3QBvbYLOZcQ4FWNtGa+h0lrxtwh7qvv6LMbv916YQ==",
       "requires": {
-        "bluebird": "^3.1.1",
-        "db-migrate-base": "^1.5.2",
-        "pg": "^7.4.1",
-        "semver": "^5.0.3"
+        "bluebird": "3.5.2",
+        "db-migrate-base": "1.5.3",
+        "pg": "7.4.3",
+        "semver": "5.5.1"
       }
     },
     "db-migrate-shared": {
@@ -931,7 +930,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-equal": {
@@ -961,7 +960,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       }
     },
     "del": {
@@ -970,13 +969,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "object-assign": {
@@ -1017,7 +1016,7 @@
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -1031,10 +1030,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1061,7 +1060,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dont-sniff-mimetype": {
@@ -1080,8 +1079,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ecdsa-sig-formatter": {
@@ -1089,7 +1088,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "ee-first": {
@@ -1108,7 +1107,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -1117,11 +1116,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1130,9 +1129,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "escape-html": {
@@ -1151,44 +1150,44 @@
       "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
+        "@babel/code-frame": "7.0.0",
+        "ajv": "6.5.4",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "4.0.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.3",
+        "globals": "11.7.0",
+        "ignore": "4.0.6",
+        "imurmurhash": "0.1.4",
+        "inquirer": "6.2.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.3",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -1197,10 +1196,10 @@
           "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-regex": {
@@ -1227,7 +1226,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1238,9 +1237,9 @@
       "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "^0.1.1",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4"
+        "eslint-restricted-globals": "0.1.1",
+        "object.assign": "4.1.0",
+        "object.entries": "1.0.4"
       }
     },
     "eslint-import-resolver-node": {
@@ -1249,8 +1248,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -1276,8 +1275,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1303,16 +1302,16 @@
       "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "dev": true,
       "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.3",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -1330,8 +1329,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "ms": {
@@ -1354,8 +1353,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -1381,8 +1380,8 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "5.7.3",
+        "acorn-jsx": "4.1.1"
       }
     },
     "esprima": {
@@ -1397,7 +1396,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -1406,7 +1405,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -1436,36 +1435,36 @@
       "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "body-parser": {
@@ -1474,15 +1473,15 @@
           "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "debug": {
@@ -1532,7 +1531,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
+                "statuses": "1.4.0"
               }
             },
             "setprototypeof": {
@@ -1564,10 +1563,10 @@
       "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
       "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
       "requires": {
-        "async": "^1.5.0",
-        "express-unless": "^0.3.0",
-        "jsonwebtoken": "^8.1.0",
-        "lodash.set": "^4.0.0"
+        "async": "1.5.2",
+        "express-unless": "0.3.1",
+        "jsonwebtoken": "8.3.0",
+        "lodash.set": "4.3.2"
       },
       "dependencies": {
         "async": {
@@ -1593,9 +1592,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "iconv-lite": {
@@ -1604,7 +1603,7 @@
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -1641,7 +1640,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1650,8 +1649,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -1667,8 +1666,8 @@
       "resolved": "https://registry.npmjs.org/final-fs/-/final-fs-1.6.1.tgz",
       "integrity": "sha1-1tzZLvb+T+jAer1WjHE1YQ7eMjY=",
       "requires": {
-        "node-fs": "~0.1.5",
-        "when": "~2.0.1"
+        "node-fs": "0.1.7",
+        "when": "2.0.1"
       }
     },
     "finalhandler": {
@@ -1677,12 +1676,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1711,8 +1710,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "fj-curry": {
@@ -1726,10 +1725,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       },
       "dependencies": {
         "circular-json": {
@@ -1750,9 +1749,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.20"
       },
       "dependencies": {
         "combined-stream": {
@@ -1760,7 +1759,7 @@
           "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         }
       }
@@ -1796,7 +1795,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.4"
       }
     },
     "fs.realpath": {
@@ -1830,14 +1829,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       },
       "dependencies": {
         "object-assign": {
@@ -1858,7 +1857,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -1866,12 +1865,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -1886,12 +1885,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.3",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -1919,10 +1918,10 @@
       "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.15.1.tgz",
       "integrity": "sha512-BfJ6BpFE93xQW69oYfgVQDxSb7LqdQbnddvhFq4tUsj7s0NAIRrrN3fmN2Bi3qpGFRemsKsWPIchw3YNNq2Xjg==",
       "requires": {
-        "lodash": "^4.17.5",
-        "nan": "^2.0.0",
-        "node-pre-gyp": "^0.10.0",
-        "protobufjs": "^5.0.3"
+        "lodash": "4.17.11",
+        "nan": "2.11.0",
+        "node-pre-gyp": "0.10.3",
+        "protobufjs": "5.0.3"
       },
       "dependencies": {
         "abbrev": {
@@ -1941,8 +1940,8 @@
           "version": "1.1.5",
           "bundled": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -1953,7 +1952,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2000,7 +1999,7 @@
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "fs.realpath": {
@@ -2011,26 +2010,26 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -2041,22 +2040,22 @@
           "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2071,7 +2070,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -2082,7 +2081,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -2093,15 +2092,15 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "mkdirp": {
@@ -2125,33 +2124,33 @@
           "version": "2.2.2",
           "bundled": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.23",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
           "version": "0.10.3",
           "bundled": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.2",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.11",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.6"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -2162,18 +2161,18 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -2188,7 +2187,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -2203,8 +2202,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -2220,40 +2219,40 @@
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
           "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
           "requires": {
-            "ascli": "~1",
-            "bytebuffer": "~5",
-            "glob": "^7.0.5",
-            "yargs": "^3.10.0"
+            "ascli": "1.0.1",
+            "bytebuffer": "5.0.1",
+            "glob": "7.1.2",
+            "yargs": "3.32.0"
           }
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -2284,23 +2283,23 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -2311,13 +2310,13 @@
           "version": "4.4.6",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -2328,7 +2327,7 @@
           "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -2351,8 +2350,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -2361,7 +2360,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-flag": {
@@ -2453,10 +2452,10 @@
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       }
     },
     "http-signature": {
@@ -2464,9 +2463,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "i": {
@@ -2479,7 +2478,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ienoopen": {
@@ -2498,7 +2497,7 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "imurmurhash": {
@@ -2517,8 +2516,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2537,19 +2536,19 @@
       "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.3",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.3.3",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2570,8 +2569,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -2580,7 +2579,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -2613,7 +2612,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -2633,7 +2632,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-ip": {
@@ -2642,7 +2641,7 @@
       "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
       "dev": true,
       "requires": {
-        "ip-regex": "^2.0.0"
+        "ip-regex": "2.1.0"
       }
     },
     "is-path-cwd": {
@@ -2657,7 +2656,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -2666,7 +2665,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-promise": {
@@ -2681,7 +2680,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-resolvable": {
@@ -2696,7 +2695,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-typedarray": {
@@ -2719,7 +2718,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
       "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -2745,8 +2744,8 @@
       "resolved": "https://registry.npmjs.org/iteray/-/iteray-0.5.1.tgz",
       "integrity": "sha1-wY5doRIT1EzzgIeHhIUWS+NfHJA=",
       "requires": {
-        "@nodeguy/generic": "^2.0.0",
-        "@nodeguy/type": "^0.2.0"
+        "@nodeguy/generic": "2.1.1",
+        "@nodeguy/type": "0.2.0"
       },
       "dependencies": {
         "@nodeguy/generic": {
@@ -2761,9 +2760,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
       "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
       "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "hoek": "5.0.4",
+        "isemail": "3.1.3",
+        "topo": "3.0.0"
       }
     },
     "js-tokens": {
@@ -2778,8 +2777,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -2814,15 +2813,15 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
       "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "requires": {
-        "jws": "^3.1.5",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1"
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1"
       }
     },
     "jsprim": {
@@ -2843,7 +2842,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "jws": {
@@ -2851,8 +2850,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "^1.1.5",
-        "safe-buffer": "^5.0.1"
+        "jwa": "1.1.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "lcid": {
@@ -2860,7 +2859,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "levn": {
@@ -2869,8 +2868,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -2879,10 +2878,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -2899,8 +2898,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -2966,10 +2965,10 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.5.tgz",
       "integrity": "sha512-IX5c3G/7fuTtdr0JjOT2OIR12aTESVhsH6cEsijloYwKgcPRlO6DgOU72v0UFhWcoV1HN6+M3dwT89qVPLXm0w==",
       "requires": {
-        "circular-json": "^0.5.5",
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "rfdc": "^1.1.2",
+        "circular-json": "0.5.7",
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "rfdc": "1.1.2",
         "streamroller": "0.7.0"
       }
     },
@@ -3008,7 +3007,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "1.36.0"
       }
     },
     "mimic-fn": {
@@ -3027,7 +3026,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -3040,8 +3039,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "minizlib": {
@@ -3049,7 +3048,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.4"
       }
     },
     "mkdirp": {
@@ -3091,12 +3090,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "supports-color": {
@@ -3105,7 +3104,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3115,7 +3114,7 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-4.1.0.tgz",
       "integrity": "sha512-asBaDLTTNpv4oC8iFdwonfMf/noPVvaBDXoSL7AsXZUDqwokgy8Lsf5eXwdnjXiDqm0olYi/S3Do544uVJSQDg==",
       "requires": {
-        "min-dash": "^3.0.0"
+        "min-dash": "3.1.0"
       }
     },
     "moddle-xml": {
@@ -3123,10 +3122,10 @@
       "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-7.2.3.tgz",
       "integrity": "sha512-QfiEJr2rnasdb7CZrKcycAgkT4c1cPR+73dwbaIgU8lx/MXzXywbG+HC+nVXae/M2rUeyTN45puBYMpLcVOdPQ==",
       "requires": {
-        "min-dash": "^3.0.0",
-        "moddle": "^4.1.0",
-        "saxen": "^8.0.0",
-        "tiny-stack": "^1.0.0"
+        "min-dash": "3.1.0",
+        "moddle": "4.1.0",
+        "saxen": "8.0.0",
+        "tiny-stack": "1.1.0"
       }
     },
     "mongodb-uri": {
@@ -3144,14 +3143,14 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.1.tgz",
       "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
       "requires": {
-        "append-field": "^0.1.0",
-        "busboy": "^0.2.11",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^3.0.0",
-        "on-finished": "^2.3.0",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "append-field": "0.1.0",
+        "busboy": "0.2.14",
+        "concat-stream": "1.6.2",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.16",
+        "xtend": "4.0.1"
       }
     },
     "mute-stream": {
@@ -3180,9 +3179,9 @@
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
       "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.23",
+        "sax": "1.2.4"
       },
       "dependencies": {
         "debug": {
@@ -3231,16 +3230,16 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
       "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
       "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.2.4",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.1.11",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.2",
+        "semver": "5.5.1",
+        "tar": "4.4.6"
       }
     },
     "nopt": {
@@ -3248,8 +3247,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
       }
     },
     "normalize-package-data": {
@@ -3258,10 +3257,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "npm": {
@@ -3269,132 +3268,132 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
       "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
       "requires": {
-        "JSONStream": "^1.3.4",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.2.0",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "ci-info": "^1.4.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.4.1",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
-        "iferr": "^1.0.2",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.6",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.2",
-        "libnpmhook": "^4.0.1",
-        "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
-        "meant": "~1.0.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.8.0",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.3.1",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.1.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.1.11",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.2",
-        "npm-registry-client": "^8.6.0",
-        "npm-registry-fetch": "^1.1.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "^1.5.0",
-        "osenv": "^0.1.5",
-        "pacote": "^8.1.6",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
-        "request": "^2.88.0",
-        "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.6",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "JSONStream": "1.3.4",
+        "abbrev": "1.1.1",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.2.0",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "ci-info": "1.4.0",
+        "cli-columns": "3.1.2",
+        "cli-table3": "0.5.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.4.1",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.7.1",
+        "iferr": "1.0.2",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.6",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "2.0.2",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.3",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.8.0",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.3.1",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.1.0",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.11",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.2",
+        "npm-registry-client": "8.6.0",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.5.0",
+        "osenv": "0.1.5",
+        "pacote": "8.1.6",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.88.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "stringify-package": "1.0.0",
+        "tar": "4.4.6",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^1.3.1",
-        "worker-farm": "^1.6.0",
-        "write-file-atomic": "^2.3.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.3.2",
+        "validate-npm-package-license": "3.0.4",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.1",
+        "worker-farm": "1.6.0",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.4",
           "bundled": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           }
         },
         "abbrev": {
@@ -3405,31 +3404,31 @@
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "es6-promisify": "5.0.0"
           }
         },
         "agentkeepalive": {
           "version": "3.4.1",
           "bundled": true,
           "requires": {
-            "humanize-ms": "^1.2.1"
+            "humanize-ms": "1.2.1"
           }
         },
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "string-width": "2.1.1"
           }
         },
         "ansi-regex": {
@@ -3440,7 +3439,7 @@
           "version": "3.2.1",
           "bundled": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "ansicolors": {
@@ -3463,8 +3462,8 @@
           "version": "1.1.4",
           "bundled": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "asap": {
@@ -3475,7 +3474,7 @@
           "version": "0.2.4",
           "bundled": true,
           "requires": {
-            "safer-buffer": "~2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "assert-plus": {
@@ -3503,25 +3502,25 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "write-file-atomic": "^2.3.0"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "bluebird": {
@@ -3532,20 +3531,20 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.4.1",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3573,20 +3572,20 @@
           "version": "11.2.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.3",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.4.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
           }
         },
         "call-limit": {
@@ -3609,9 +3608,9 @@
           "version": "2.4.1",
           "bundled": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "chownr": {
@@ -3626,7 +3625,7 @@
           "version": "2.0.9",
           "bundled": true,
           "requires": {
-            "ip-regex": "^2.1.0"
+            "ip-regex": "2.1.0"
           }
         },
         "cli-boxes": {
@@ -3637,26 +3636,26 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
           }
         },
         "cli-table3": {
           "version": "0.5.0",
           "bundled": true,
           "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
-            "string-width": "^2.1.1"
+            "colors": "1.1.2",
+            "object-assign": "4.1.1",
+            "string-width": "2.1.1"
           }
         },
         "cliui": {
           "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3667,7 +3666,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -3680,8 +3679,8 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
         },
         "co": {
@@ -3696,7 +3695,7 @@
           "version": "1.9.1",
           "bundled": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "1.1.3"
           }
         },
         "color-name": {
@@ -3712,15 +3711,15 @@
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
           }
         },
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -3731,30 +3730,30 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
           }
         },
         "configstore": {
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "console-control-strings": {
@@ -3765,12 +3764,12 @@
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
+            "aproba": "1.2.0",
+            "fs-write-stream-atomic": "1.0.10",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
             "iferr": {
@@ -3787,16 +3786,16 @@
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "capture-stack-trace": "^1.0.0"
+            "capture-stack-trace": "1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "crypto-random-string": {
@@ -3811,7 +3810,7 @@
           "version": "1.14.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "debug": {
@@ -3847,7 +3846,7 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "clone": "^1.0.2"
+            "clone": "1.0.4"
           }
         },
         "delayed-stream": {
@@ -3870,15 +3869,15 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
+            "asap": "2.0.6",
+            "wrappy": "1.0.2"
           }
         },
         "dot-prop": {
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         },
         "dotenv": {
@@ -3893,10 +3892,10 @@
           "version": "3.6.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -3904,8 +3903,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2"
           }
         },
         "editor": {
@@ -3916,14 +3915,14 @@
           "version": "0.1.12",
           "bundled": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
+            "iconv-lite": "0.4.23"
           }
         },
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "err-code": {
@@ -3934,7 +3933,7 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "prr": "~1.0.1"
+            "prr": "1.0.1"
           }
         },
         "es6-promise": {
@@ -3945,7 +3944,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "es6-promise": "^4.0.3"
+            "es6-promise": "4.2.4"
           }
         },
         "escape-string-regexp": {
@@ -3956,13 +3955,13 @@
           "version": "0.7.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "extend": {
@@ -3993,15 +3992,15 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.4"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "forever-agent": {
@@ -4012,43 +4011,43 @@
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.19"
           }
         },
         "from2": {
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "iferr": {
@@ -4065,33 +4064,33 @@
           "version": "1.0.11",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
           }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -4104,14 +4103,14 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -4132,43 +4131,43 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4"
+            "ini": "1.3.5"
           }
         },
         "got": {
           "version": "6.7.1",
           "bundled": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -4183,8 +4182,8 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "ajv": "^5.3.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "has-flag": {
@@ -4207,7 +4206,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "agent-base": "4",
+            "agent-base": "4.2.0",
             "debug": "3.1.0"
           }
         },
@@ -4215,31 +4214,31 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
           }
         },
         "https-proxy-agent": {
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
           }
         },
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "ms": "^2.0.0"
+            "ms": "2.1.1"
           }
         },
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "iferr": {
@@ -4250,7 +4249,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "import-lazy": {
@@ -4265,8 +4264,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -4281,14 +4280,14 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.4",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "invert-kv": {
@@ -4307,36 +4306,36 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "1.4.0"
           }
         },
         "is-cidr": {
           "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "2.0.9"
           }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
           "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
           }
         },
         "is-npm": {
@@ -4351,7 +4350,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "path-is-inside": "^1.0.1"
+            "path-is-inside": "1.0.2"
           }
         },
         "is-redirect": {
@@ -4421,7 +4420,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "package-json": "4.0.1"
           }
         },
         "lazy-property": {
@@ -4432,46 +4431,46 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "libcipm": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.2",
-            "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^2.0.3",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "pacote": "^8.1.6",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.13",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.6.0"
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "mkdirp": "0.5.1",
+            "npm-lifecycle": "2.1.0",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "8.1.6",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
           }
         },
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "figgy-pudding": "3.4.1",
+            "npm-registry-fetch": "3.1.1"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.4.1",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
               }
             }
           }
@@ -4480,37 +4479,37 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.1",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lock-verify": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "^3.0.2"
+            "signal-exit": "3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -4521,8 +4520,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           }
         },
         "lodash._bindcallback": {
@@ -4537,7 +4536,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
         },
         "lodash._createset": {
@@ -4580,32 +4579,32 @@
           "version": "4.1.3",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "make-fetch-happen": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agentkeepalive": "^3.4.1",
-            "cacache": "^11.0.1",
-            "http-cache-semantics": "^3.8.1",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
-            "mississippi": "^3.0.0",
-            "node-fetch-npm": "^2.0.2",
-            "promise-retry": "^1.1.1",
-            "socks-proxy-agent": "^4.0.0",
-            "ssri": "^6.0.0"
+            "agentkeepalive": "3.4.1",
+            "cacache": "11.2.0",
+            "http-cache-semantics": "3.8.1",
+            "http-proxy-agent": "2.1.0",
+            "https-proxy-agent": "2.2.1",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "node-fetch-npm": "2.0.2",
+            "promise-retry": "1.1.1",
+            "socks-proxy-agent": "4.0.1",
+            "ssri": "6.0.0"
           }
         },
         "meant": {
@@ -4616,7 +4615,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "mime-db": {
@@ -4627,7 +4626,7 @@
           "version": "2.1.19",
           "bundled": true,
           "requires": {
-            "mime-db": "~1.35.0"
+            "mime-db": "1.35.0"
           }
         },
         "mimic-fn": {
@@ -4638,7 +4637,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -4649,8 +4648,8 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -4663,23 +4662,23 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.0",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.3",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
           }
         },
         "mkdirp": {
@@ -4693,12 +4692,12 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           }
         },
         "ms": {
@@ -4713,34 +4712,34 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "encoding": "^0.1.11",
-            "json-parse-better-errors": "^1.0.0",
-            "safe-buffer": "^5.1.1"
+            "encoding": "0.1.12",
+            "json-parse-better-errors": "1.0.2",
+            "safe-buffer": "5.1.2"
           }
         },
         "node-gyp": {
           "version": "3.8.0",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "^2.87.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.88.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.1"
           },
           "dependencies": {
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -4751,9 +4750,9 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               }
             }
           }
@@ -4762,26 +4761,26 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.7.1",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.4"
           }
         },
         "npm-audit-report": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "cli-table3": "^0.5.0",
-            "console-control-strings": "^1.1.0"
+            "cli-table3": "0.5.0",
+            "console-control-strings": "1.1.0"
           }
         },
         "npm-bundled": {
@@ -4796,21 +4795,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.8.0",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.8.0",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.1"
+            "umask": "1.1.0",
+            "which": "1.3.1"
           }
         },
         "npm-logical-tree": {
@@ -4821,52 +4820,52 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.7.1",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.5"
           }
         },
         "npm-pick-manifest": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "npm-profile": {
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2 || 2",
-            "make-fetch-happen": "^2.5.0 || 3 || 4"
+            "aproba": "1.2.0",
+            "make-fetch-happen": "4.0.1"
           }
         },
         "npm-registry-client": {
           "version": "8.6.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
+            "concat-stream": "1.6.2",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.88.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
           },
           "dependencies": {
             "retry": {
@@ -4877,7 +4876,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -4886,47 +4885,47 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "cacache": {
               "version": "10.0.4",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
               },
               "dependencies": {
                 "mississippi": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.2",
+                    "duplexify": "3.6.0",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.3",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "2.0.1",
+                    "pumpify": "1.5.1",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   }
                 }
               }
@@ -4939,25 +4938,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
               }
             },
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             },
             "smart-buffer": {
@@ -4968,23 +4967,23 @@
               "version": "1.1.10",
               "bundled": true,
               "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
+                "ip": "1.1.5",
+                "smart-buffer": "1.1.15"
               }
             },
             "socks-proxy-agent": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "agent-base": "^4.1.0",
-                "socks": "^1.1.10"
+                "agent-base": "4.2.0",
+                "socks": "1.1.10"
               }
             },
             "ssri": {
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -4993,7 +4992,7 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "npm-user-validate": {
@@ -5004,10 +5003,10 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -5026,7 +5025,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
@@ -5041,9 +5040,9 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "os-tmpdir": {
@@ -5054,8 +5053,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "p-finally": {
@@ -5066,14 +5065,14 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.2.0"
           }
         },
         "p-try": {
@@ -5084,50 +5083,50 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "pacote": {
           "version": "8.1.6",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "bluebird": "3.5.1",
+            "cacache": "11.2.0",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "minipass": "2.3.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.11",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.6",
+            "unique-filename": "1.1.0",
+            "which": "1.3.1"
           }
         },
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
+            "cyclist": "0.2.2",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "path-exists": {
@@ -5170,8 +5169,8 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
+            "err-code": "1.1.2",
+            "retry": "0.10.1"
           },
           "dependencies": {
             "retry": {
@@ -5184,7 +5183,7 @@
           "version": "0.3.0",
           "bundled": true,
           "requires": {
-            "read": "1"
+            "read": "1.0.7"
           }
         },
         "proto-list": {
@@ -5195,7 +5194,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "4.0.1"
           }
         },
         "prr": {
@@ -5214,25 +5213,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
           "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
+            "duplexify": "3.6.0",
+            "inherits": "2.0.3",
+            "pump": "2.0.1"
           },
           "dependencies": {
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             }
           }
@@ -5253,8 +5252,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "strict-uri-encode": "^2.0.0"
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
           }
         },
         "qw": {
@@ -5265,10 +5264,10 @@
           "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5281,113 +5280,113 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "0.0.7"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           }
         },
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.2",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           }
         },
         "read-package-tree": {
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
           }
         },
         "registry-auth-token": {
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
+            "rc": "1.2.7",
+            "safe-buffer": "5.1.2"
           }
         },
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "^1.0.1"
+            "rc": "1.2.7"
           }
         },
         "request": {
           "version": "2.88.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.8.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.1.0",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.19",
+            "oauth-sign": "0.9.0",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.4.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "require-directory": {
@@ -5410,14 +5409,14 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1"
+            "aproba": "1.2.0"
           }
         },
         "safe-buffer": {
@@ -5436,7 +5435,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "semver": "^5.0.3"
+            "semver": "5.5.0"
           }
         },
         "set-blocking": {
@@ -5447,15 +5446,15 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -5482,16 +5481,16 @@
           "version": "2.2.0",
           "bundled": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "ip": "1.1.5",
+            "smart-buffer": "4.0.1"
           }
         },
         "socks-proxy-agent": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "4.2.0",
+            "socks": "2.2.0"
           }
         },
         "sorted-object": {
@@ -5502,16 +5501,16 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               }
             },
             "isarray": {
@@ -5522,10 +5521,10 @@
               "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -5538,8 +5537,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -5550,8 +5549,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -5562,15 +5561,15 @@
           "version": "1.14.2",
           "bundled": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.4",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.2",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
           }
         },
         "ssri": {
@@ -5581,16 +5580,16 @@
           "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "stream-shift": "1.0.0"
           }
         },
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "stream-shift": "^1.0.0"
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "stream-shift": {
@@ -5605,8 +5604,8 @@
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -5621,7 +5620,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -5630,7 +5629,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "stringify-package": {
@@ -5641,7 +5640,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-eof": {
@@ -5656,20 +5655,20 @@
           "version": "5.4.0",
           "bundled": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "tar": {
           "version": "4.4.6",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -5682,7 +5681,7 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0"
+            "execa": "0.7.0"
           }
         },
         "text-table": {
@@ -5697,8 +5696,8 @@
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "timed-out": {
@@ -5713,15 +5712,15 @@
           "version": "2.4.3",
           "bundled": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "1.1.29",
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "tweetnacl": {
@@ -5745,21 +5744,21 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "imurmurhash": "^0.1.4"
+            "imurmurhash": "0.1.4"
           }
         },
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "crypto-random-string": "^1.0.0"
+            "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
@@ -5774,23 +5773,23 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         },
         "util-deprecate": {
@@ -5809,38 +5808,38 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
           }
         },
         "verror": {
           "version": "1.10.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           }
         },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "defaults": "^1.0.3"
+            "defaults": "1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -5851,16 +5850,16 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -5869,31 +5868,31 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "~0.1.7"
+            "errno": "0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -5906,9 +5905,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         },
         "xdg-basedir": {
@@ -5931,18 +5930,18 @@
           "version": "11.0.0",
           "bundled": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -5955,7 +5954,7 @@
           "version": "9.0.2",
           "bundled": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -5970,8 +5969,8 @@
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
       "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
       "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.5"
       }
     },
     "npmlog": {
@@ -5979,10 +5978,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -6012,10 +6011,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
       }
     },
     "object.entries": {
@@ -6024,10 +6023,10 @@
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "on-finished": {
@@ -6043,7 +6042,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -6052,7 +6051,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optimist": {
@@ -6060,8 +6059,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "optionator": {
@@ -6070,12 +6069,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -6101,7 +6100,7 @@
       "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -6114,8 +6113,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "p-limit": {
@@ -6124,7 +6123,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -6133,7 +6132,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -6152,7 +6151,7 @@
       "resolved": "https://registry.npmjs.org/parse-database-url/-/parse-database-url-0.3.0.tgz",
       "integrity": "sha1-NpZmMh6SfJreY838Gqr2+zdFPQ0=",
       "requires": {
-        "mongodb-uri": ">= 0.9.7"
+        "mongodb-uri": "0.9.7"
       }
     },
     "parse-json": {
@@ -6161,7 +6160,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parseurl": {
@@ -6174,7 +6173,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
       "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
       "requires": {
-        "passport-strategy": "1.x.x",
+        "passport-strategy": "1.0.0",
         "pause": "0.0.1"
       }
     },
@@ -6183,8 +6182,8 @@
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
       "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
       "requires": {
-        "jsonwebtoken": "^8.2.0",
-        "passport-strategy": "^1.0.0"
+        "jsonwebtoken": "8.3.0",
+        "passport-strategy": "1.0.0"
       }
     },
     "passport-local": {
@@ -6192,7 +6191,7 @@
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
       "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
       "requires": {
-        "passport-strategy": "1.x.x"
+        "passport-strategy": "1.0.0"
       }
     },
     "passport-strategy": {
@@ -6205,8 +6204,8 @@
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
       "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
       "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
+        "process": "0.11.10",
+        "util": "0.10.4"
       }
     },
     "path-exists": {
@@ -6215,7 +6214,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -6251,7 +6250,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "pathval": {
@@ -6278,9 +6277,9 @@
         "buffer-writer": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "~2.0.3",
-        "pg-types": "~1.12.1",
-        "pgpass": "1.x",
+        "pg-pool": "2.0.3",
+        "pg-types": "1.12.1",
+        "pgpass": "1.0.2",
         "semver": "4.3.2"
       },
       "dependencies": {
@@ -6306,10 +6305,10 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
       "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
       "requires": {
-        "postgres-array": "~1.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
-        "postgres-interval": "^1.1.0"
+        "postgres-array": "1.0.3",
+        "postgres-bytea": "1.0.0",
+        "postgres-date": "1.0.3",
+        "postgres-interval": "1.1.2"
       }
     },
     "pgpass": {
@@ -6317,7 +6316,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
       "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
       "requires": {
-        "split": "^1.0.0"
+        "split": "1.0.1"
       }
     },
     "pify": {
@@ -6338,7 +6337,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -6347,7 +6346,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkginfo": {
@@ -6386,7 +6385,7 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
       "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
       "requires": {
-        "xtend": "^4.0.0"
+        "xtend": "4.0.1"
       }
     },
     "prelude-ls": {
@@ -6416,12 +6415,12 @@
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
       "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
       "requires": {
-        "colors": "^1.1.2",
-        "pkginfo": "0.x.x",
-        "read": "1.0.x",
-        "revalidator": "0.1.x",
-        "utile": "0.3.x",
-        "winston": "2.1.x"
+        "colors": "1.3.2",
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.3.0",
+        "winston": "2.1.1"
       }
     },
     "protobufjs": {
@@ -6429,19 +6428,19 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/base64": "1.1.2",
+        "@protobufjs/codegen": "2.0.4",
+        "@protobufjs/eventemitter": "1.1.0",
+        "@protobufjs/fetch": "1.1.0",
+        "@protobufjs/float": "1.0.2",
+        "@protobufjs/inquire": "1.1.0",
+        "@protobufjs/path": "1.1.2",
+        "@protobufjs/pool": "1.1.0",
+        "@protobufjs/utf8": "1.1.0",
+        "@types/long": "4.0.0",
+        "@types/node": "10.11.7",
+        "long": "4.0.0"
       },
       "dependencies": {
         "@types/node": {
@@ -6456,7 +6455,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -6507,10 +6506,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "deep-extend": {
@@ -6530,7 +6529,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-pkg": {
@@ -6539,9 +6538,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -6550,8 +6549,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -6560,7 +6559,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -6570,13 +6569,13 @@
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "referrer-policy": {
@@ -6595,26 +6594,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "require-uncached": {
@@ -6623,8 +6622,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -6632,7 +6631,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-from": {
@@ -6647,8 +6646,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "revalidator": {
@@ -6666,7 +6665,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "run-async": {
@@ -6675,7 +6674,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rxjs": {
@@ -6684,7 +6683,7 @@
       "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -6718,18 +6717,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -6757,9 +6756,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -6779,7 +6778,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -6799,7 +6798,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -6816,8 +6815,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-exceptions": {
@@ -6832,8 +6831,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-license-ids": {
@@ -6847,7 +6846,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "sprintf-js": {
@@ -6861,9 +6860,9 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.2.tgz",
       "integrity": "sha512-51ferIRwYOhzUEtogqOa/y9supADlAht98bF/gbIi6WkzRJX6Yioldxbzj1MV4yV+LgdKD/kkHwFTeFXOG4htA==",
       "requires": {
-        "nan": "~2.10.0",
-        "node-pre-gyp": "^0.10.3",
-        "request": "^2.87.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.3",
+        "request": "2.88.0"
       },
       "dependencies": {
         "nan": {
@@ -6878,7 +6877,7 @@
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.4.tgz",
       "integrity": "sha1-G/a2soyW6u8mf01sRqWiUXpZnic=",
       "requires": {
-        "ssh2-streams": "~0.1.15"
+        "ssh2-streams": "0.1.20"
       }
     },
     "ssh2-streams": {
@@ -6886,9 +6885,9 @@
       "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
       "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
       "requires": {
-        "asn1": "~0.2.0",
-        "semver": "^5.1.0",
-        "streamsearch": "~0.1.2"
+        "asn1": "0.2.4",
+        "semver": "5.5.1",
+        "streamsearch": "0.1.2"
       }
     },
     "sshpk": {
@@ -6896,15 +6895,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -6922,10 +6921,10 @@
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "requires": {
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "readable-stream": "^2.3.0"
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "mkdirp": "0.5.1",
+        "readable-stream": "2.3.6"
       }
     },
     "streamsearch": {
@@ -6938,9 +6937,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -6948,7 +6947,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -6956,7 +6955,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -6964,7 +6963,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-json-comments": {
@@ -6978,16 +6977,16 @@
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "dev": true,
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.2",
+        "debug": "3.1.0",
+        "extend": "3.0.2",
+        "form-data": "2.3.2",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.4.1",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6"
       }
     },
     "supertest": {
@@ -6996,8 +6995,8 @@
       "integrity": "sha512-dMQSzYdaZRSANH5LL8kX3UpgK9G1LRh/jnggs/TI0W2Sz7rkMx9Y48uia3K9NgcaWEV28tYkBnXE4tiFC77ygQ==",
       "dev": true,
       "requires": {
-        "methods": "^1.1.2",
-        "superagent": "^3.8.3"
+        "methods": "1.1.2",
+        "superagent": "3.8.3"
       }
     },
     "supports-color": {
@@ -7005,7 +7004,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "table": {
@@ -7014,12 +7013,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "6.5.4",
+        "ajv-keywords": "3.2.0",
+        "chalk": "2.4.1",
+        "lodash": "4.17.11",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -7028,10 +7027,10 @@
           "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-regex": {
@@ -7064,8 +7063,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -7074,7 +7073,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -7084,13 +7083,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
       "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.4",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "text-table": {
@@ -7115,7 +7114,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "toml": {
@@ -7128,7 +7127,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
       "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.4"
       }
     },
     "tough-cookie": {
@@ -7136,8 +7135,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       }
     },
     "tslib": {
@@ -7151,7 +7150,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tunnel-ssh": {
@@ -7160,7 +7159,7 @@
       "integrity": "sha512-CjBqboGvAbM7iXSX2F95kzoI+c2J81YkrHbyyo4SWNKCzU6w5LfEvXBCHu6PPriYaNvfhMKzD8bFf5Vl14YTtg==",
       "requires": {
         "debug": "2.6.9",
-        "lodash.defaults": "^4.1.0",
+        "lodash.defaults": "4.2.0",
         "ssh2": "0.5.4"
       },
       "dependencies": {
@@ -7191,7 +7190,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
@@ -7206,7 +7205,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.20"
       }
     },
     "typedarray": {
@@ -7225,7 +7224,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -7259,12 +7258,12 @@
       "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
       "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
       "requires": {
-        "async": "~0.9.0",
-        "deep-equal": "~0.2.1",
-        "i": "0.3.x",
-        "mkdirp": "0.x.x",
-        "ncp": "1.0.x",
-        "rimraf": "2.x.x"
+        "async": "0.9.2",
+        "deep-equal": "0.2.2",
+        "i": "0.3.6",
+        "mkdirp": "0.5.1",
+        "ncp": "1.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -7290,8 +7289,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -7304,9 +7303,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "web3": {
@@ -7315,15 +7314,14 @@
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "requires": {
         "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2": "*",
-        "xmlhttprequest": "*"
+        "crypto-js": "3.1.4",
+        "utf8": "2.1.2",
+        "xhr2": "0.1.4",
+        "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         }
       }
     },
@@ -7338,7 +7336,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "wide-align": {
@@ -7346,7 +7344,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
@@ -7359,13 +7357,13 @@
       "resolved": "http://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
       "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "pkginfo": "0.3.x",
-        "stack-trace": "0.0.x"
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
@@ -7395,8 +7393,8 @@
       "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -7410,7 +7408,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "x-xss-protection": {
@@ -7428,8 +7426,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -7462,13 +7460,13 @@
       "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
       }
     }
   }

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,11 +1,12 @@
-FROM ethereum/solc:0.4.25 as solc-builder
-FROM hyperledger/burrow:0.22.0
+ARG BURROW_VERSION=0.23.1
+FROM hyperledger/burrow:$BURROW_VERSION
 USER root
 
 RUN apk add --update --no-cache bash curl jq
-COPY --from=solc-builder /usr/bin/solc /usr/local/bin/
 
 COPY . /app
 WORKDIR /app
+
 ENTRYPOINT []
+
 CMD ["./deploy_contracts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3"
 services:
   hoard:
     image: quay.io/monax/hoard:1.1.3
+    ports:
+      - "53431"
   postgres:
     image: postgres:9-alpine
     ports:
@@ -38,7 +40,7 @@ services:
     - postgres
     - chain
   chain:
-    image: hyperledger/burrow:0.23.0
+    image: hyperledger/burrow:0.23.1-dev-2018-11-14-f23fae1e
     expose:
     - "10997"
     volumes:
@@ -47,7 +49,11 @@ services:
     command:
       - start
   api:
-    image: quay.io/monax/build:latest
+    build:
+      context: .
+      args:
+        USER: $USER
+        UID: $UID
     environment:
       CI_PROJECT_DIR: /app
       HOARD_IP: hoard:53431

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,15 @@ services:
     - postgres
     - chain
   chain:
+    image: hyperledger/burrow:0.23.0
+    expose:
+    - "10997"
+    volumes:
+    - ./test/chain:/chain
+    working_dir: /chain
+    command:
+      - start
+  api:
     image: quay.io/monax/build:latest
     environment:
       CI_PROJECT_DIR: /app
@@ -49,13 +58,12 @@ services:
     ports:
     - "3080:3080"
     - "9222:9222"
-    expose:
-    - "10997"
     working_dir: /app
     depends_on:
     - postgres
     - hoard
     links:
+    - chain
     - postgres
     - hoard
     command: "test/test_api.sh --runAPI"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   postgres:
     image: postgres:9-alpine
     ports:
-    - "5432:5432"
+    - "5432"
     environment:
       POSTGRES_USER: blackstone_development
       POSTGRES_PASSWORD: blackstone_development
@@ -16,8 +16,11 @@ services:
     # We could reference hyperledger/burrow:$version directly here but for the sake of only specifying our dependency version
     # once we do it in the project Dockerfile
     build: .
-    expose:
+    ports:
+    # GRPC port for most interaction
     - "10997"
+    # HTTP status/information port
+    - "26658"
     volumes:
     - ./test/chain:/chain
     working_dir: /chain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,18 @@ services:
       POSTGRES_USER: blackstone_development
       POSTGRES_PASSWORD: blackstone_development
       POSTGRES_DB: blackstone_development
+  chain:
+    # We could reference hyperledger/burrow:$version directly here but for the sake of only specifying our dependency version
+    # once we do it in the project Dockerfile
+    build: .
+    expose:
+    - "10997"
+    volumes:
+    - ./test/chain:/chain
+    working_dir: /chain
+    command:
+    - burrow
+    - start
   vent:
     image: quay.io/monax/vent:develop
     restart: always
@@ -36,24 +48,8 @@ services:
     depends_on:
     - postgres
     - chain
-    links:
-    - postgres
-    - chain
-  chain:
-    image: hyperledger/burrow:0.23.1-dev-2018-11-14-f23fae1e
-    expose:
-    - "10997"
-    volumes:
-    - ./test/chain:/chain
-    working_dir: /chain
-    command:
-      - start
   api:
-    build:
-      context: .
-      args:
-        USER: $USER
-        UID: $UID
+    build: .
     environment:
       CI_PROJECT_DIR: /app
       HOARD_IP: hoard:53431
@@ -68,8 +64,6 @@ services:
     depends_on:
     - postgres
     - hoard
-    links:
+    - vent
     - chain
-    - postgres
-    - hoard
     command: "test/test_api.sh --runAPI"

--- a/test/chain/burrow.toml
+++ b/test/chain/burrow.toml
@@ -3,11 +3,12 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
 [GenesisDoc]
   GenesisTime = 2018-07-24T13:48:52Z
   ChainName = "BurrowChain_1267BB"
+  [GenesisDoc.Params]
+    ProposalThreshold = 3
   [GenesisDoc.GlobalPermissions]
-    Roles = []
     [GenesisDoc.GlobalPermissions.Base]
-      Perms = 2302
-      SetBit = 16383
+      Perms = "send | call | createContract | createAccount | bond | name | proposal | input | batch | hasBase | hasRole"
+      SetBit = "root | send | call | createContract | createAccount | bond | name | proposal | input | batch | hasBase | setBase | unsetBase | setGlobal | hasRole | addRole | removeRole"
 
   [[GenesisDoc.Accounts]]
     Address = "0201EF325305ABD75E1FB8A8F539730F71547484"
@@ -16,8 +17,8 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
     Name = "Full_0"
     [GenesisDoc.Accounts.Permissions]
       [GenesisDoc.Accounts.Permissions.Base]
-        Perms = 16383
-        SetBit = 16383
+        Perms = "root | send | call | createContract | createAccount | bond | name | proposal | input | batch | hasBase | setBase | unsetBase | setGlobal | hasRole | addRole | removeRole"
+        SetBit = "root | send | call | createContract | createAccount | bond | name | proposal | input | batch | hasBase | setBase | unsetBase | setGlobal | hasRole | addRole | removeRole"
 
   [[GenesisDoc.Accounts]]
     Address = "F390C8CA854874472CAD38C0135F78097BCB632D"
@@ -26,8 +27,8 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
     Name = "billings"
     [GenesisDoc.Accounts.Permissions]
       [GenesisDoc.Accounts.Permissions.Base]
-        Perms = 16383
-        SetBit = 16383
+        Perms = "root | send | call | createContract | createAccount | bond | name | proposal | input | batch | hasBase | setBase | unsetBase | setGlobal | hasRole | addRole | removeRole"
+        SetBit = "root | send | call | createContract | createAccount | bond | name | proposal | input | batch | hasBase | setBase | unsetBase | setGlobal | hasRole | addRole | removeRole"
 
   [[GenesisDoc.Accounts]]
     Address = "93FE25A9897601EEF7779F1A53EFB8C0B433DA78"
@@ -36,8 +37,8 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
     Name = "Participant_1"
     [GenesisDoc.Accounts.Permissions]
       [GenesisDoc.Accounts.Permissions.Base]
-        Perms = 2118
-        SetBit = 2118
+        Perms = "send | call | name | proposal | input | hasRole"
+        SetBit = "send | call | name | proposal | input | hasRole"
 
   [[GenesisDoc.Accounts]]
     Address = "D1382AC92725F71F571E1BC898E8D8BFBBC35CA8"
@@ -46,8 +47,8 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
     Name = "Participant_2"
     [GenesisDoc.Accounts.Permissions]
       [GenesisDoc.Accounts.Permissions.Base]
-        Perms = 2118
-        SetBit = 2118
+        Perms = "send | call | name | proposal | input | hasRole"
+        SetBit = "send | call | name | proposal | input | hasRole"
 
   [[GenesisDoc.Accounts]]
     Address = "3D27518E4EBEA14AE69120D5043D2E4F5C4F1D06"
@@ -56,8 +57,8 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
     Name = "Participant_3"
     [GenesisDoc.Accounts.Permissions]
       [GenesisDoc.Accounts.Permissions.Base]
-        Perms = 2118
-        SetBit = 2118
+        Perms = "send | call | name | proposal | input | hasRole"
+        SetBit = "send | call | name | proposal | input | hasRole"
 
   [[GenesisDoc.Accounts]]
     Address = "0D073D962573D5E23E68FB1DE831D48F6FFD8041"
@@ -66,8 +67,8 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
     Name = "Participant_4"
     [GenesisDoc.Accounts.Permissions]
       [GenesisDoc.Accounts.Permissions.Base]
-        Perms = 2118
-        SetBit = 2118
+        Perms = "send | call | name | proposal | input | hasRole"
+        SetBit = "send | call | name | proposal | input | hasRole"
 
   [[GenesisDoc.Validators]]
     Address = "0201EF325305ABD75E1FB8A8F539730F71547484"
@@ -113,6 +114,7 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
   NonBlocking = false
   [Logging.RootSink]
     [Logging.RootSink.Output]
-      OutputType = "stderr"
+      OutputType = "file"
       Format = "json"
+      Path = "burrow.log"
 

--- a/test/clean
+++ b/test/clean
@@ -6,12 +6,12 @@ pkill -f "burrow"
 
 if ! [[ "$CI" = true ]]; then
   # files and dirs accumulated during chain deployment/testing
-  rm $CI_PROJECT_DIR/burrow.log
+  rm -f $CI_PROJECT_DIR/burrow.log
   rm -rf $CI_PROJECT_DIR/test/chain/.burrow
 
   #files and dirs accumulated during contracts deployment/testing
-  rm $CI_PROJECT_DIR/contracts/src/*.output.json
-  rm $CI_PROJECT_DIR/test*.log
+  rm -f $CI_PROJECT_DIR/contracts/src/*.output.json
+  rm -f $CI_PROJECT_DIR/test*.log
   rm -rf $CI_PROJECT_DIR/contracts/src/bin
 
   # files and dirs accumulated by API deployment/testing

--- a/test/clean
+++ b/test/clean
@@ -2,10 +2,9 @@
 set +e
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/preflight"
 
-pkill -f "monax-keys"
 pkill -f "burrow"
 
-if ! [ "$CI" = true ]; then
+if ! [[ "$CI" = true ]]; then
   # files and dirs accumulated during chain deployment/testing
   rm $CI_PROJECT_DIR/burrow.log
   rm -rf $CI_PROJECT_DIR/test/chain/.burrow

--- a/test/preflight
+++ b/test/preflight
@@ -20,3 +20,28 @@ export WEBAPP_NAME=${WEBAPP_NAME:-"Monax Application"}
 export WEBAPP_EMAIL=${WEBAPP_EMAIL:-"help@$org_url"}
 export CONTRACTS_DEPLOYMENT_ADDRESS="F390C8CA854874472CAD38C0135F78097BCB632D"
 
+deploy_local() {
+  echo "Hello! I'm the marmot who tests the Monax Agreements Network API."
+
+  export CHAIN_URL_INFO="chain:26658"
+  export CHAIN_URL_GRPC="chain:10997"
+  sleep 3
+  $CI_PROJECT_DIR/contracts/deploy_contracts
+
+  echo
+  echo "#### Copying public ABIs to $API_ABI_DIRECTORY_LOCAL"
+  configApp
+
+  echo
+  echo "#### Agreements Network contracts successfully deployed"
+}
+
+configApp() {
+  set +e
+  mkdir -p $API_ABI_DIRECTORY_LOCAL
+  while read -r abi; do
+    cp $CONTRACTS_DIRECTORY/bin/$abi.bin $API_ABI_DIRECTORY_LOCAL/$abi.bin
+  done < $CI_PROJECT_DIR/contracts/abi.csv
+  set -e
+}
+

--- a/test/preflight
+++ b/test/preflight
@@ -5,7 +5,6 @@
 for var in "$@"
 do
   if [[ $var == "--runAPI" ]]; then runAPI=true; fi
-  if [[ $var == "--skipChain" ]]; then skipChain=true; fi
 done
 
 # ----------------------------------------------------------
@@ -19,7 +18,5 @@ export API_ABI_DIRECTORY_LOCAL=${API_ABI_DIRECTORY_LOCAL:-"$CI_PROJECT_DIR/api/p
 export CONTRACTS_DIRECTORY=${CONTRACTS_DIRECTORY:-"$CI_PROJECT_DIR/contracts/src"}
 export WEBAPP_NAME=${WEBAPP_NAME:-"Monax Application"}
 export WEBAPP_EMAIL=${WEBAPP_EMAIL:-"help@$org_url"}
-export CHAIN_SOURCE_DIRECTORY=$CI_PROJECT_DIR/test/chain
 export CONTRACTS_DEPLOYMENT_ADDRESS="F390C8CA854874472CAD38C0135F78097BCB632D"
-
 

--- a/test/preflight
+++ b/test/preflight
@@ -22,44 +22,4 @@ export WEBAPP_EMAIL=${WEBAPP_EMAIL:-"help@$org_url"}
 export CHAIN_SOURCE_DIRECTORY=$CI_PROJECT_DIR/test/chain
 export CONTRACTS_DEPLOYMENT_ADDRESS="F390C8CA854874472CAD38C0135F78097BCB632D"
 
-# ----------------------------------------------------------
-#  functions
-test_setup(){
-  echo "Setting up..."
-  cd $CHAIN_SOURCE_DIRECTORY
 
-  if [[ "$skipChain" = true ]]; then
-    echo "Not booting Burrow, but expecting burrow to be running default ports"
-  else
-    rm -rf $CHAIN_SOURCE_DIRECTORY/.burrow
-    burrow start 2>>$CI_PROJECT_DIR/burrow.log &
-    burrow_pid=$!
-  fi
-
-  cd $CI_PROJECT_DIR
-  echo "Setup complete"
-}
-
-test_teardown(){
-  echo "Cleaning up..."
-
-  if ! [[ "$skipChain" = true ]]; then
-    kill ${burrow_pid}
-    wait ${burrow_pid} 2> /dev/null &
-    sleep 1 #ensure it's dead
-    rm -rf $CHAIN_SOURCE_DIRECTORY/.burrow
-  fi
-
-  if [ ${#failures[@]} -eq 0 ]
-  then
-    echo "Tests are Green. :)"
-  else
-    cat $CI_PROJECT_DIR/test-contracts.log
-    echo
-    echo "Tests are Red. :("
-    printf 'Failed bundle:\n\n%s\n' "${failures[@]}"
-  fi
-
-  cd $CI_PROJECT_DIR
-  exit ${#failures[@]}
-}

--- a/test/test_api.sh
+++ b/test/test_api.sh
@@ -28,9 +28,8 @@ main() {
 deploy_local() {
   echo "Hello! I'm the marmot who tests the Monax Agreements Network API."
 
-  export CHAIN_URL_INFO="localhost:26658"
-  export CHAIN_URL_GRPC="localhost:10997"
-  test_setup
+  export CHAIN_URL_INFO="chain:26658"
+  export CHAIN_URL_GRPC="chain:10997"
   sleep 3
   $CI_PROJECT_DIR/contracts/deploy_contracts
 

--- a/test/test_api.sh
+++ b/test/test_api.sh
@@ -24,30 +24,5 @@ main() {
 
 }
 
-deploy_local() {
-  echo "Hello! I'm the marmot who tests the Monax Agreements Network API."
-
-  export CHAIN_URL_INFO="chain:26658"
-  export CHAIN_URL_GRPC="chain:10997"
-  sleep 3
-  $CI_PROJECT_DIR/contracts/deploy_contracts
-
-  echo
-  echo "#### Copying public ABIs to $API_ABI_DIRECTORY_LOCAL"
-  configApp
-
-  echo
-  echo "#### Agreements Network contracts successfully deployed"
-}
-
-configApp() {
-  set +e
-  mkdir -p $API_ABI_DIRECTORY_LOCAL
-  while read -r abi; do
-    cp $CONTRACTS_DIRECTORY/bin/$abi.bin $API_ABI_DIRECTORY_LOCAL/$abi.bin
-  done < $CI_PROJECT_DIR/contracts/abi.csv
-  set -e
-}
-
 set -e
 main $@

--- a/test/test_api.sh
+++ b/test/test_api.sh
@@ -3,7 +3,6 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/preflight"
 
 main() {
   deploy_local
-  deploy_vent
 
   if [[ $1 == "deploy" ]]; then
     exit 0
@@ -39,11 +38,6 @@ deploy_local() {
 
   echo
   echo "#### Agreements Network contracts successfully deployed"
-}
-
-deploy_vent() {
-  ./bos/vent --db-adapter=postgres --db-url=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/blackstone_development?sslmode=disable \
-      --db-schema=blackstone_development --grpc-addr=${CHAIN_URL_GRPC} --log-level=error --spec-file=./api/sqlsol/Tables.spec --abi-dir=./contracts/src/ &
 }
 
 configApp() {

--- a/test/test_bundle.sh
+++ b/test/test_bundle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-deploy_cmd="burrow deploy --chain-url=localhost:10997 --mempool-signing --address $CONTRACTS_DEPLOYMENT_ADDRESS --file $1"
+deploy_cmd="burrow deploy --chain-url=chain:10997 --mempool-signing --address $CONTRACTS_DEPLOYMENT_ADDRESS --file $1"
 echo
 echo -e "Testing bundle:\t\t\t\t\t\t\t\t=> $1"
 echo -e "executing:\t$deploy_cmd"

--- a/test/test_contracts.sh
+++ b/test/test_contracts.sh
@@ -5,7 +5,6 @@ main() {
   echo "Hello! I'm the marmot that tests the contracts."
 
   cd $CI_PROJECT_DIR
-  test_setup
   sleep 3
   cd $CONTRACTS_DIRECTORY
 
@@ -28,7 +27,6 @@ main() {
     failures=($(awk 'NR==1{for(i=1;i<=NF;i++){if($i=="Exitval"){c=i;break}}} ($c=="1"&& NR>1){print $NF}' $CI_PROJECT_DIR/test-contracts-jobs.log))
     echo "Tests complete"
 
-    test_teardown
   fi
 }
 


### PR DESCRIPTION
This:

- Drops the use of monax/build for anything
- Introduces a Dockerfile that builds a test service called 'api' through which most command are run (instead of 'chain')
- Makes chain a separate service that just runs burrow (it could use the vanilla Burrow image - would look cleaner but would mean two places to update docker image.
- Runs the exact same docker-compose based tests (`make test`) in CI as in dev