### PR TITLE
Feature AN-544: Make agreement processes optional

### DIFF
--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -1075,7 +1075,7 @@ const isValidProcess = processAddress => new Promise((resolve, reject) => {
 
 const startProcessFromAgreement = agreementAddress => new Promise((resolve, reject) => {
   log.trace(`Starting formation process from agreement at address: ${agreementAddress}`);
-  appManager.contracts['ActiveAgreementRegistry'].factory.startFormation(agreementAddress, (error, data) => {
+  appManager.contracts['ActiveAgreementRegistry'].factory.startProcessLifecycle(agreementAddress, (error, data) => {
     if (error || !data.raw) {
       return reject(boom
         .badImplementation(`Failed to start formation process from agreement at ${agreementAddress}: ${error}`));

--- a/contracts/build_contracts
+++ b/contracts/build_contracts
@@ -6,7 +6,7 @@ main() {
     cd "$(dirname "${BASH_SOURCE[0]}")/src"
 
     build_file="build.yaml"
-    [[ -z "$1" ]] || build_file="build-$1.yaml"
+    [[ -z "$1" ]] || build_file="build-$1"
 
     echo "Building contract suite from $(readlink -f "$build_file")"
 

--- a/contracts/src/agreements/ActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/ActiveAgreementRegistry.sol
@@ -151,12 +151,14 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	function addAgreementToCollection(bytes32 _collectionId, address _agreement) public;
 
 	/**
-	 * @dev Creates a starts a ProcessInstance to handle the formation workflow as defined by the given agreement's archetype.
+	 * @dev Creates and starts a ProcessInstance to handle the workflows as defined by the given agreement's archetype.
+	 * Depending on the configuration in the archetype, the returned address could be a formation process or
+	 * execution process.
 	 * @param _agreement an ActiveAgreement
 	 * @return error - an error code indicating success or failure
-	 * @return the address of the ProcessInstance, if successful
+	 * @return the address of a ProcessInstance, if successful
 	 */
-	function startFormation(ActiveAgreement _agreement) external returns (uint error, address processInstance);
+	function startProcessLifecycle(ActiveAgreement _agreement) external returns (uint error, address processInstance);
 
 	/**
 	 * @dev Sets address scopes on the given ProcessInstance based on the scopes defined in the ActiveAgreement referenced in the ProcessInstance.
@@ -178,32 +180,32 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	 */
 	function getArchetypeRegistry() external returns (address);
 
-  /**
-   * @dev Gets number of activeAgreements
-   * @return size size
-   */
-  function getActiveAgreementsSize() external view returns (uint size);
+	/**
+	 * @dev Gets number of activeAgreements
+	 * @return size size
+	 */
+	function getActiveAgreementsSize() external view returns (uint size);
 
-  /**
-   * @dev Gets activeAgreement address at given index
-   * @param _index index
-   * @return the Active Agreement address
-   */
-  function getActiveAgreementAtIndex(uint _index) external view returns (address activeAgreement);
+	/**
+	 * @dev Gets activeAgreement address at given index
+	 * @param _index index
+	 * @return the Active Agreement address
+	 */
+	function getActiveAgreementAtIndex(uint _index) external view returns (address activeAgreement);
 
-  /**
-   * @dev Gets parties size for given Active Agreement
-   * @param _activeAgreement Active Agreement
-   * @return size size
-   */
+	/**
+	 * @dev Gets parties size for given Active Agreement
+	 * @param _activeAgreement Active Agreement
+	 * @return size size
+	 */
 	function getPartiesByActiveAgreementSize(address _activeAgreement) external view returns (uint size);
 
-  /**
-   * @dev Gets getPartyByActiveAgreementAtIndex
-   * @param _activeAgreement Active Agreement
-   * @param _index index
-   * @return party party
-   */
+	/**
+	 * @dev Gets getPartyByActiveAgreementAtIndex
+	 * @param _activeAgreement Active Agreement
+	 * @param _index index
+	 * @return party party
+	 */
 	function getPartyByActiveAgreementAtIndex(address _activeAgreement, uint _index) public view returns (address party);
 
     /**

--- a/contracts/src/agreements/DefaultArchetypeRegistry.sol
+++ b/contracts/src/agreements/DefaultArchetypeRegistry.sol
@@ -58,7 +58,9 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		address[] _governingArchetypes) 
 		external returns (address archetype)
 	{
-		validateArchetypeRequirements(_name, _author, _formationProcess, _executionProcess, _governingArchetypes);
+		ErrorsLib.revertIf(bytes(_name).length == 0 || _author == 0x0,
+			ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultArchetypeRegistry.createArchetype", "Archetype name and author address must not be empty");
+		verifyNoDuplicates(_governingArchetypes);
 		archetype = new DefaultArchetype(_price, _isPrivate, _active, _name, _author, _description,  _formationProcess, _executionProcess, _governingArchetypes);
 		registerArchetype(archetype, _name);
 		for (uint i = 0; i < _governingArchetypes.length; i++) {
@@ -71,18 +73,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 			);
 		}
 		if (_packageId != "") addArchetypeToPackage(_packageId, archetype);
-	}
-
-	function validateArchetypeRequirements(string _name, address _author, address _formationProcess, address _executionProcess, address[] _governingArchetypes) internal {
-		validateArchetypeProperties(_name, _author);
-		ErrorsLib.revertIf(_formationProcess == 0x0 || _executionProcess == 0x0,
-			ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultArchetypeRegistry.createArchetype", "Archetype name, author address, formation and execution process definitions are required");
-		verifyNoDuplicates(_governingArchetypes);
-	}
-
-	function validateArchetypeProperties(string _name, address _author) internal pure {
-		ErrorsLib.revertIf(bytes(_name).length == 0 || _author == 0x0,
-			ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultArchetypeRegistry.createArchetype", "Archetype name, author address, formation and execution process definitions are required");
 	}
 
 	function registerArchetype(address _archetype, string _name) internal {

--- a/contracts/src/agreements/test/ArchetypeRegistryTest.sol
+++ b/contracts/src/agreements/test/ArchetypeRegistryTest.sol
@@ -48,19 +48,9 @@ contract ArchetypeRegistryTest {
 	address[] ndaGovArchetypes;
 	address[] emptyArray;
 
-	// TODO: Reinstate the constructor when the issue below is resolved.
-	// ISSUE: EPM does not pass params via a constructor when it deploys a contract from binary.
-	// So had to add a getter/setter below instead of using constructor. See AN-307
-	// constructor(address _isoCountries) {
-	// 	isoCountries = IsoCountries100(_isoCountries);
-	// }
-
-	function setIsoCountries(address _isoCountries) external {
+	constructor (address _isoCountries) public {
+		require(_isoCountries != address(0), "The test contract requires an instance of IsoCountries");
 		isoCountries = IsoCountries100(_isoCountries);
-	}
-
-	function getIsoCountries() external view returns (address) {
-		return address(isoCountries);
 	}
 
 	/**
@@ -85,7 +75,7 @@ contract ArchetypeRegistryTest {
 			"createArchetype(bytes32,address,string,bool,bool,address,address,bytes32,address[])"))),
 			name, 0x0, description, false, true, 0x0, 0x0, EMPTY, addrArrayWithDupes)) 
 		{
-			return "Creating archetype with empty author expected to fail with NULL_PARAM_NOT_ALLOWED";
+			return "Creating archetype with empty author expected to fail";
 		}
 
 		archetype = registry.createArchetype(10, false, true, name, falseAddress, description, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);

--- a/contracts/src/test-agreements.yaml
+++ b/contracts/src/test-agreements.yaml
@@ -56,25 +56,7 @@ jobs:
     contract: ArchetypeRegistryTest.bin
     instance: ArchetypeRegistryTest
     libraries: ErrorsLib:$ErrorsLib, ArrayUtilsAPI:$ArrayUtilsAPI, TypeUtilsAPI:$TypeUtilsAPI, MappingsLib:$MappingsLib
-
-- name: setIsoCountries
-  call:
-    destination: $ArchetypeRegistryTest
-    bin: ArchetypeRegistryTest
-    function: setIsoCountries
     data: [$IsoCountries]
-
-- name: getIsoCountries
-  call:
-    destination: $ArchetypeRegistryTest
-    bin: ArchetypeRegistryTest
-    function: getIsoCountries
-
-- name: assertIsoCountries
-  assert:
-    key: $getIsoCountries
-    relation: eq
-    val: $IsoCountries
 
 - name: testArchetypeCreation
   call:
@@ -437,6 +419,18 @@ jobs:
 - name: assertAddressScopeTransfer
   assert:
     key: $testAddressScopeTransfer
+    relation: eq
+    val: success
+
+- name: testAgreementProcessLifecycle
+  call:
+    destination: $ActiveAgreementWorkflowTest
+    bin: ActiveAgreementWorkflowTest
+    function: testAgreementProcessLifecycle
+
+- name: assertAgreementProcessLifecycle
+  assert:
+    key: $testAgreementProcessLifecycle
     relation: eq
     val: success
 


### PR DESCRIPTION
The PR adds changes to the DefaultArchetypeRegistry to not require formation and execution process definitions when creating archetypes. Also, DefaultActiveAgreementRegistry was changed to deal with agreements from archetypes with varying combinations of formation / execution workflows (or their lack).