### PR TITLE
Hotfix/address scopes

### DIFF
--- a/api/common/controller-dependencies.js
+++ b/api/common/controller-dependencies.js
@@ -120,19 +120,10 @@ const dependencies = {
         element.isPrivate = Boolean(element.isPrivate);
         break;
       case 'Task':
-        if (element.activityId) element.activityId = global.hexToString(element.activityId);
-        if (element.processDefinitionId) element.processDefinitionId = global.hexToString(element.processDefinitionId);
-        if (element.modelId) element.modelId = global.hexToString(element.modelId);
-        if (element.processName) element.processName = global.hexToString(element.processName);
-        if (element.application) element.application = global.hexToString(element.application);
-        if (element.webForm) element.webForm = global.hexToString(element.webForm || '');
         if (element.scope && element.scope !== element.organizationKey) {
           // organizationKey was originally entered in bytes32 and doesn't need to be converted to string
           element.scope = global.hexToString(element.scope || '');
         }
-        delete element.organizationKey;
-        if (element.created) element.created *= 1000;
-        if (element.completed) element.completed *= 1000;
         break;
       case 'ParameterType':
         element.label = global.hexToString(element.label || '');

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -671,8 +671,7 @@
       },
       "fixed_scope": {
         "name": "fixed_scope",
-        "type": "bytes32",
-        "bytesToString": true
+        "type": "bytes32"
       },
       "data_path": {
         "name": "data_path",


### PR DESCRIPTION
Back to bytes32 column for address scope because if "all org. members" option is selected, the value entered for this field will be the `organization_key`, a bytes32 hex value which upsets vent.
Convert hex -> string after query as needed.
Also adding performer name to activity instance data.