### PR TITLE
Hotfix/revert fixed scope col type

### DIFF
--- a/api/common/controller-dependencies.js
+++ b/api/common/controller-dependencies.js
@@ -120,19 +120,10 @@ const dependencies = {
         element.isPrivate = Boolean(element.isPrivate);
         break;
       case 'Task':
-        if (element.activityId) element.activityId = global.hexToString(element.activityId);
-        if (element.processDefinitionId) element.processDefinitionId = global.hexToString(element.processDefinitionId);
-        if (element.modelId) element.modelId = global.hexToString(element.modelId);
-        if (element.processName) element.processName = global.hexToString(element.processName);
-        if (element.application) element.application = global.hexToString(element.application);
-        if (element.webForm) element.webForm = global.hexToString(element.webForm || '');
         if (element.scope && element.scope !== element.organizationKey) {
           // organizationKey was originally entered in bytes32 and doesn't need to be converted to string
           element.scope = global.hexToString(element.scope || '');
         }
-        delete element.organizationKey;
-        if (element.created) element.created *= 1000;
-        if (element.completed) element.completed *= 1000;
         break;
       case 'ParameterType':
         element.label = global.hexToString(element.label || '');

--- a/api/controllers/bpm-controller.js
+++ b/api/controllers/bpm-controller.js
@@ -22,7 +22,7 @@ const dataStorage = require(path.join(`${global.__controllers}/data-storage-cont
 const getActivityInstances = asyncMiddleware(async (req, res) => {
   const data = await sqlCache.getActivityInstances(req.query);
   const activities = await pgCache.populateTaskNames(data);
-  return res.status(200).json(activities);
+  return res.status(200).json(activities.map(activity => format('Task', activity)));
 });
 
 const _getDataMappingDetails = async (userAddress, activityInstanceId, dataMappingIds = [], direction) => {
@@ -182,7 +182,7 @@ const getActivityInstance = asyncMiddleware(async (req, res) => {
     return res.status(200).json(activityInstanceResult);
   } catch (err) {
     log.error(`Failed to get data mappings for activity ${req.params.id} and user ${req.user.address}: ${err}`);
-    return res.status(200).json(activityInstanceResult);
+    return res.status(200).json(format('Task', activityInstanceResult));
   }
 });
 
@@ -213,7 +213,7 @@ const getTasksForUser = asyncMiddleware(async ({ user: { address } }, res) => {
   if (!address) throw boom.badRequest('No logged in user found');
   const data = await sqlCache.getTasksByUserAddress(address);
   const tasks = await pgCache.populateTaskNames(data);
-  return res.status(200).json(tasks);
+  return res.status(200).json(tasks.map(task => format('Task', task)));
 });
 
 const getModels = asyncMiddleware(async (req, res) => {

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -671,8 +671,7 @@
       },
       "fixed_scope": {
         "name": "fixed_scope",
-        "type": "bytes32",
-        "bytesToString": true
+        "type": "bytes32"
       },
       "data_path": {
         "name": "data_path",


### PR DESCRIPTION
Back to bytes32 column for address scope because if "all org. members" option is selected, the value entered for this field will be the organization_key, a bytes32 hex value which upsets vent.
Convert hex -> string after query as needed.