### PR TITLE
WIP: Feature/MP-628 ProcessModelRepository 1.1.0 upgrade script

### DIFF
--- a/contracts/src/bpm-model/DefaultProcessModelRepository.sol
+++ b/contracts/src/bpm-model/DefaultProcessModelRepository.sol
@@ -17,7 +17,7 @@ import "bpm-model/ProcessModelRepositoryDb.sol";
  * @title DefaultProcessModelRepository
  * @dev Default implementation of the ProcessModelRepository interface
  */
-contract DefaultProcessModelRepository is Versioned(1,0,0), AbstractEventListener, ProcessModelRepository, AbstractDbUpgradeable {
+contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListener, ProcessModelRepository, AbstractDbUpgradeable {
 	
 	string constant TABLE_PROCESS_MODELS = "PROCESS_MODELS";
 	string constant TABLE_PROCESS_DEFINITIONS = "PROCESS_DEFINITIONS";

--- a/contracts/src/commons-management/AbstractUpgradeable.sol
+++ b/contracts/src/commons-management/AbstractUpgradeable.sol
@@ -23,11 +23,14 @@ contract AbstractUpgradeable is Versioned, UpgradeOwned, AbstractERC165, Upgrade
     }
 
     /**
-     * @dev Blocks the call to a function if the supplied Versioned contract address is not higher than this contract's version
+     * @dev Checks if the supplied Versioned contract address is higher than this contract's version.
+     * REVERTS if:
+     * - the supplied Versioned contract does not have a higher version than this contract.
      */
     modifier pre_higherVersionOnly(address _newVersion) {
-        if (compareVersion(_newVersion) > 0)
-            _;
+        ErrorsLib.revertIf(compareVersion(_newVersion) < 1,
+            ErrorsLib.INVALID_INPUT(), "AbstractUpgradeable.pre_higherVersionOnly", "The upgrade successor must have a higher version than the current contract.");
+        _;
     }
 
     /**

--- a/contracts/upgrade/ProcessModelRepository-1.1.0.yaml
+++ b/contracts/upgrade/ProcessModelRepository-1.1.0.yaml
@@ -1,0 +1,122 @@
+jobs:
+
+#####
+# Retrieve DOUG
+#####
+- name: DOUG
+  query-name:
+      name: DOUG
+      field: data
+
+#####
+# Retrieve Library Addresses
+#####
+- name: ErrorsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [ErrorsLib]
+
+- name: TypeUtils
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [TypeUtils]
+
+- name: ArrayUtils
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [ArrayUtils]
+
+- name: MappingsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [MappingsLib]
+
+- name: BpmModelLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [BpmModelLib]
+
+- name: DataStorageUtils
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [DataStorageUtils]
+
+#####
+# ProcessModelRepository (old)
+#####
+- name: OldProcessModelRepository
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookupContract
+    data: [ProcessModelRepository]
+
+- name: OldProcessModelRepositoryVersion
+  query-contract:
+    destination: $OldProcessModelRepository
+    bin: ProcessModelRepository
+    function: getVersion
+
+- name: OldProcessModelRepositoryNumberOfModels
+  query-contract:
+    destination: $OldProcessModelRepository
+    bin: ProcessModelRepository
+    function: getNumberOfModels
+
+#####
+# ProcessModelRepository (new)
+######
+- name: NewProcessModelRepository
+  deploy:
+    contract: DefaultProcessModelRepository.bin
+    libraries: ErrorsLib:$ErrorsLib, TypeUtilsAPI:$TypeUtils, ArrayUtilsAPI:$ArrayUtils, MappingsLib:$MappingsLib, BpmModelLib:$BpmModelLib, DataStorageUtils:$DataStorageUtils
+
+- name: ChangeRepositoryUpgradeOwnership
+  call:
+    destination: $NewProcessModelRepository
+    bin: UpgradeOwned
+    function: transferUpgradeOwnership
+    data: [$DOUG]
+
+- name: DeployNewProcessModelRepository
+  call:
+    destination: $DOUG
+    bin: DOUG
+    function: deployContract
+    data: [ProcessModelRepository, $NewProcessModelRepository]
+
+- name: AssertProcessModelRepositoryUpgradeSuccess
+  assert:
+    key: $DeployNewProcessModelRepository
+    relation: eq
+    val: "true"
+
+- name: NewProcessModelRepositoryVersion
+  query-contract:
+    destination: $NewProcessModelRepository
+    bin: ProcessModelRepository
+    function: getVersion
+
+- name: NewProcessModelRepositoryNumberOfModels
+  query-contract:
+    destination: $NewProcessModelRepository
+    bin: ProcessModelRepository
+    function: getNumberOfModels
+
+- name: AssertProcessModelRepositoryUpgradeSize
+  assert:
+    key: $NewProcessModelRepositoryNumberOfModels
+    relation: eq
+    val: $OldProcessModelRepositoryNumberOfModels


### PR DESCRIPTION
This PR increases the version of the DefaultProcessModelRepository to 1.1.0 to upgrade existing production systems with the changes made in DefaultProcessModel and DefaultProcessDefinition regarding the emittance of additional events for data-mappings.
An upgrade yaml script was added to perform the incremental update on top of an existing deployment. It upgrades the "ProcessModelRepository" contract registered in DOUG and re-deploys the DataTypesAccess contract to emit new storage data.