### PR TITLE
Use docker-compose file version 3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   hoard:
     image: quay.io/monax/hoard:1.1.3


### PR DESCRIPTION
Gives us `target` keyword and should work with our machine version:

> circleci/classic:201808-01 – docker 18.06.0-ce, docker-compose 1.22.0