### PR TITLE
Bump Vent to version that only consumes EVM log events and filters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     - -c
     - burrow start &> burrow.log
   vent:
-    image: quay.io/monax/vent:0.0.5
+    image: quay.io/monax/vent:0.0.6
     restart: always
     command:
     - --db-adapter


### PR DESCRIPTION
burrow-side

Signed-off-by: Silas Davis <silas@monax.io>