### PR TITLE
Hotfix/address scopes table consolidation

### DIFF
--- a/api/controllers/postgres-query-helper.js
+++ b/api/controllers/postgres-query-helper.js
@@ -431,8 +431,8 @@ const getActivityInstanceData = (id, userAddress) => {
     LEFT JOIN agreements agr ON agr.agreement_address = ds.address_value
     LEFT JOIN applications app ON app.application_id = ad.application
     LEFT JOIN organization_accounts o ON o.organization_address = ai.performer 
-    LEFT JOIN process_instance_address_scopes scopes ON (
-      scopes.process_instance_address = ds.storage_address 
+    LEFT JOIN entities_address_scopes scopes ON (
+      scopes.entity_address = ds.storage_address 
       AND scopes.scope_address = ai.performer 
       AND scopes.scope_context = ai.activity_id
     )
@@ -496,8 +496,8 @@ const getTasksByUserAddress = (userAddress) => {
     LEFT JOIN data_storage ds ON ai.process_instance_address = ds.storage_address
     LEFT JOIN agreements agr ON agr.agreement_address = ds.address_value
     LEFT JOIN organization_accounts o ON o.organization_address = ai.performer
-    LEFT JOIN process_instance_address_scopes scopes ON (
-      scopes.process_instance_address = ds.storage_address
+    LEFT JOIN entities_address_scopes scopes ON (
+      scopes.entity_address = ds.storage_address
       AND scopes.scope_address = ai.performer 
       AND scopes.scope_context = ai.activity_id
     )
@@ -564,8 +564,8 @@ const getDataMappingsForActivity = (activityInstanceId, dataMappingId) => {
     pmd.data_id = COALESCE(NULLIF(dm.data_storage_id, ''), 'PROCESS_INSTANCE') AND
     pmd.data_path = dm.data_path
   )
-  LEFT JOIN process_instance_address_scopes scopes ON (
-    ai.process_instance_address = scopes.process_instance_address AND 
+  LEFT JOIN entities_address_scopes scopes ON (
+    ai.process_instance_address = scopes.entity_address AND 
     ai.activity_id = scopes.scope_context AND
     pmd.data_id = COALESCE(NULLIF(scopes.data_storage_id, ''), 'PROCESS_INSTANCE') AND
     pmd.data_path = scopes.data_path

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -178,22 +178,24 @@
     }
   },
   {
-    "TableName": "AGREEMENT_ADDRESS_SCOPES",
-    "Filter": "Log1Text = 'AN://agreements/scopes'",
+    "TableName": "ENTITIES_ADDRESS_SCOPES",
+    "Filter": "Log1Text = 'AN://entities/address-scopes'",
     "Columns": {
-      "agreementAddress": {
-        "name": "agreement_address",
+      "entityAddress": {
+        "name": "entity_address",
         "type": "address",
         "primary": true
       },
       "scopeAddress": {
         "name": "scope_address",
-        "type": "address"
+        "type": "address",
+        "primary": true
       },
       "scopeContext": {
         "name": "scope_context",
         "type": "bytes32",
-        "bytesToString": true
+        "bytesToString": true,
+        "primary": true
       },
       "fixedScope": {
         "name": "fixed_scope",
@@ -762,44 +764,6 @@
       "stringValue": {
         "name": "string_value",
         "type": "string"
-      }
-    }
-  },
-  {
-    "TableName": "PROCESS_INSTANCE_ADDRESS_SCOPES",
-    "Filter": "Log1Text = 'AN://process-instances/scopes'",
-    "Columns": {
-      "processInstanceAddress": {
-        "name": "process_instance_address",
-        "type": "address",
-        "primary": true
-      },
-      "scopeAddress": {
-        "name": "scope_address",
-        "type": "address"
-      },
-      "scopeContext": {
-        "name": "scope_context",
-        "type": "bytes32",
-        "bytesToString": true
-      },
-      "fixedScope": {
-        "name": "fixed_scope",
-        "type": "bytes32"
-      },
-      "dataPath": {
-        "name": "data_path",
-        "type": "bytes32",
-        "bytesToString": true
-      },
-      "dataStorageId": {
-        "name": "data_storage_id",
-        "type": "bytes32",
-        "bytesToString": true
-      },
-      "dataStorage": {
-        "name": "data_storage",
-        "type": "address"
       }
     }
   },

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -61,21 +61,9 @@ contract ActiveAgreement is VersionedArtifact, Named, DataStorage, AddressScopes
 		string governingAgreementName
 	);
 
-	event LogAgreementAddressScopesUpdate(
-		bytes32 indexed eventId,
-		address agreementAddress,
-		address scopeAddress,
-		bytes32 scopeContext,
-		bytes32 fixedScope,
-		bytes32 dataPath,
-		bytes32 dataStorageId,
-		address dataStorage
-	);
-
 	bytes32 public constant EVENT_ID_AGREEMENTS = "AN://agreements";
 	bytes32 public constant EVENT_ID_AGREEMENT_PARTY_MAP = "AN://agreement-to-party";
 	bytes32 public constant EVENT_ID_GOVERNING_AGREEMENT = "AN://governing-agreements";
-	bytes32 public constant EVENT_ID_AGREEMENT_ADDRESS_SCOPES = "AN://agreements/scopes";
 
 	bytes32 public constant DATA_FIELD_AGREEMENT_PARTIES = "AGREEMENT_PARTIES";
 

--- a/contracts/src/agreements/DefaultActiveAgreement.sol
+++ b/contracts/src/agreements/DefaultActiveAgreement.sol
@@ -364,23 +364,4 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,0), AbstractDel
 		}
 	}
 
-    /**
-     * @dev Overwrites AbstractAddressScopes.setAddressScope() in order to emit an event in the context of this ActiveAgreement
-     */
-	function setAddressScope(address _address, bytes32 _context, bytes32 _fixedScope, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage)
-		public
-	{
-        super.setAddressScope(_address, _context, _fixedScope, _dataPath, _dataStorageId, _dataStorage);
-        emit LogAgreementAddressScopesUpdate(
-            EVENT_ID_AGREEMENT_ADDRESS_SCOPES,
-            address(this),
-            _address,
-            _context,
-            _fixedScope,
-            _dataPath,
-            _dataStorageId,
-            _dataStorage
-        );        
-    }
-
 }

--- a/contracts/src/bpm-runtime/DefaultProcessInstance.sol
+++ b/contracts/src/bpm-runtime/DefaultProcessInstance.sol
@@ -612,23 +612,4 @@ contract DefaultProcessInstance is AbstractVersionedArtifact(1,0,0), AbstractDel
         }
     }
 
-    /**
-     * @dev Overwrites AbstractAddressScopes.setAddressScope() in order to emit an event in the context of this ActiveAgreement
-     */
-	function setAddressScope(address _address, bytes32 _context, bytes32 _fixedScope, bytes32 _dataPath, bytes32 _dataStorageId, address _dataStorage)
-		public
-	{
-        super.setAddressScope(_address, _context, _fixedScope, _dataPath, _dataStorageId, _dataStorage);
-        emit LogProcessInstanceAddressScopesUpdate(
-            EVENT_ID_PROCESS_INSTANCE_ADDRESS_SCOPES,
-            address(this),
-            _address,
-            _context,
-            _fixedScope,
-            _dataPath,
-            _dataStorageId,
-            _dataStorage
-        );        
-    }
-
 }

--- a/contracts/src/bpm-runtime/ProcessInstance.sol
+++ b/contracts/src/bpm-runtime/ProcessInstance.sol
@@ -29,19 +29,7 @@ contract ProcessInstance is VersionedArtifact, DataStorage, AddressScopes, Owner
 		uint8 state
 	);
 
-	event LogProcessInstanceAddressScopesUpdate(
-		bytes32 indexed eventId,
-		address processInstanceAddress,
-		address scopeAddress,
-		bytes32 scopeContext,
-		bytes32 fixedScope,
-		bytes32 dataPath,
-		bytes32 dataStorageId,
-		address dataStorage
-	);
-
 	bytes32 public constant EVENT_ID_PROCESS_INSTANCES = "AN://process-instances";
-	bytes32 public constant EVENT_ID_PROCESS_INSTANCE_ADDRESS_SCOPES = "AN://process-instances/scopes";
 
     /**
 	 * @dev Initializes this ProcessInstance with the provided parameters. This function replaces the

--- a/contracts/src/commons-collections/AbstractAddressScopes.sol
+++ b/contracts/src/commons-collections/AbstractAddressScopes.sol
@@ -69,6 +69,17 @@ contract AbstractAddressScopes is AddressScopes {
             addressScopes[key].scope.conditionalScope = DataStorageUtils.ConditionalData({dataPath: _dataPath, dataStorageId: _dataStorageId, dataStorage: _dataStorage, exists: true});
         }
 		addressScopes[key].exists = true;
+        emit LogEntityAddressScopeUpdate(
+            EVENT_ID_ENTITIES_ADDRESS_SCOPES,
+            address(this),
+            _address,
+            _context,
+            _fixedScope,
+            _dataPath,
+            _dataStorageId,
+            _dataStorage
+        );        
+
 	}
 
 	/**

--- a/contracts/src/commons-collections/AddressScopes.sol
+++ b/contracts/src/commons-collections/AddressScopes.sol
@@ -9,6 +9,19 @@ import "commons-collections/DataStorage.sol";
  */
 contract AddressScopes {
 
+	event LogEntityAddressScopeUpdate(
+		bytes32 indexed eventId,
+		address entityAddress,
+		address scopeAddress,
+		bytes32 scopeContext,
+		bytes32 fixedScope,
+		bytes32 dataPath,
+		bytes32 dataStorageId,
+		address dataStorage
+	);
+
+	bytes32 public constant EVENT_ID_ENTITIES_ADDRESS_SCOPES = "AN://entities/address-scopes";
+
 	/**
 	 * @dev Associates the given address with a scope qualifier for a given context.
 	 * The context can be used to bind the same address to different scenarios and different scopes.


### PR DESCRIPTION
This PR consolidates the AGREEMENT_ADDRESS_SCOPES and PROCESS_INSTANCE_ADDRESS_SCOPES into a single table ENTITIES_ADDRESS_SCOPES and fixes a bug with the table's primary key not not combining enough columns and causing entries to be overwritten.