### PR TITLE
MP-683-add-account-details-to-parameters

### DIFF
--- a/api/common/controller-dependencies.js
+++ b/api/common/controller-dependencies.js
@@ -39,18 +39,6 @@ const dependencies = {
     const element = Object.assign({}, obj);
     const err = new Error();
     switch (type) {
-      case 'Organization':
-        break;
-      case 'User':
-        delete element.organization;
-        Object.keys(element).forEach((key) => {
-          const camelKey = _.camelCase(key);
-          if (key !== camelKey) {
-            element[camelKey] = element[key];
-            delete element[key];
-          }
-        });
-        break;
       case 'Access Point':
         element.accessPointId = global.hexToString(element.accessPointId);
         break;
@@ -280,49 +268,26 @@ const dependencies = {
     };
   },
 
-  setUserIds: (users, registeredUsersOnly, ...formats) => new Promise((resolve, reject) => {
-    const text = `SELECT username AS id, address FROM users 
-    WHERE address = ANY ($1)
+  getParticipantNames: async (participants, registeredUsersOnly, addressKey = 'address') => {
+    const text = `SELECT username AS id, NULL AS name, address, external_user FROM users
+    UNION
+    SELECT NULL AS id, name, address, FALSE AS external_user FROM organizations
+    WHERE address = ANY($1)
     ${registeredUsersOnly ? ' AND external_user = false;' : ';'}`;
     try {
-      app_db_pool.query({
+      const { rows: withNames } = await app_db_pool.query({
         text,
-        values: [users.map(user => user.address)],
-      }, (err, res) => {
-        if (err) reject(boom.badImplementation(err));
-        const userIds = {};
-        res.rows.forEach((user) => {
-          userIds[user.address] = user.id;
-        });
-        const _users = users.map((_user) => {
-          let user = Object.assign({}, _user);
-          user.id = userIds[user.address];
-          formats.forEach((format) => {
-            user = dependencies.format(format, user);
-          });
-          return user;
-        }).filter(({ id }) => id);
-        resolve(_users);
+        values: [participants.map(({ [addressKey]: address }) => address)],
       });
-    } catch (err) {
-      reject(err);
-    }
-  }),
-
-  getNamesOfOrganizations: async (organizations) => {
-    try {
-      const { rows } = await app_db_pool.query({
-        text: 'SELECT DISTINCT address, name FROM organizations WHERE address = ANY ($1)',
-        values: [organizations.map(({ address }) => address)],
+      const names = {};
+      withNames.forEach(({ address, id, name }) => {
+        names[address] = {};
+        if (id) names[address].id = id;
+        if (name) names[address].name = name;
       });
-      const completeOrgs = {};
-      organizations.forEach((org) => {
-        completeOrgs[org.address] = { ...org, name: '' };
-      });
-      rows.forEach(({ address, name }) => {
-        completeOrgs[address].name = name;
-      });
-      return Object.values(completeOrgs);
+      const returnData = participants.map(account => Object.assign(account, names[account[addressKey]]));
+      if (registeredUsersOnly) return returnData.filter(({ id, name }) => id || name);
+      return returnData;
     } catch (err) {
       throw boom.badImplementation(err);
     }

--- a/api/controllers/bpm-controller.js
+++ b/api/controllers/bpm-controller.js
@@ -7,8 +7,6 @@ const {
   splitMeta,
   asyncMiddleware,
   byteLength,
-  setUserIds,
-  getNamesOfOrganizations,
 } = require(`${global.__common}/controller-dependencies`);
 const logger = require(`${global.__common}/monax-logger`);
 const log = logger.getLogger('agreements.bpm');
@@ -100,11 +98,6 @@ const getActivityInstance = asyncMiddleware(async (req, res) => {
   let activityInstanceResult = (await sqlCache.getActivityInstanceData(req.params.id, req.user.address))[0];
   if (!activityInstanceResult) throw boom.notFound(`Activity instance ${req.params.id} not found or user not authorized`);
   activityInstanceResult = (await pgCache.populateTaskNames([activityInstanceResult]))[0];
-  activityInstanceResult.performerName = (await setUserIds([{ address: activityInstanceResult.performer }]))[0];
-  if (!activityInstanceResult.performerName) {
-    activityInstanceResult.performerName = (await getNamesOfOrganizations([{ address: activityInstanceResult.performer }]))[0];
-  }
-  activityInstanceResult.performerName = activityInstanceResult.performerName.id || activityInstanceResult.performerName.name;
   activityInstanceResult.data = await sqlCache.getDataMappingsForActivity(req.params.id);
   activityInstanceResult.data = addDataTypes(activityInstanceResult.data);
   try {

--- a/api/controllers/participants-controller.js
+++ b/api/controllers/participants-controller.js
@@ -10,8 +10,7 @@ const sqlCache = require('./postgres-query-helper');
 const {
   format,
   pgUpdate,
-  setUserIds,
-  getNamesOfOrganizations,
+  getParticipantNames,
   asyncMiddleware,
   getSHA256Hash,
   prependHttps,
@@ -39,7 +38,7 @@ const getOrganizations = asyncMiddleware(async (req, res) => {
       }
       aggregated[address].approvers.push(approver);
     });
-    const organizations = await getNamesOfOrganizations(Object.values(aggregated));
+    const organizations = await getParticipantNames(Object.values(aggregated));
     return res.json(organizations);
   } catch (err) {
     if (boom.isBoom(err)) throw err;
@@ -83,12 +82,12 @@ const getOrganization = asyncMiddleware(async (req, res) => {
       throw boom.forbidden('User is not an approver or member of this organization and not allowed access');
     }
     const { address, organizationKey } = data[0];
-    const { 0: { name } } = await getNamesOfOrganizations([{ address }]);
+    const { 0: { name } } = await getParticipantNames([{ address }]);
     const org = {
       address, organizationKey, name, approvers, users, departments,
     };
-    org.approvers = await setUserIds(org.approvers);
-    org.users = await setUserIds(org.users);
+    org.approvers = await getParticipantNames(org.approvers);
+    org.users = await getParticipantNames(org.users);
     return res.status(200).send(org);
   } catch (err) {
     if (boom.isBoom(err)) throw err;
@@ -402,15 +401,16 @@ const getProfile = asyncMiddleware(async (req, res) => {
       organizations[organization].departments.push({ id, name: departmentName });
     }
   });
-  user.organizations = await getNamesOfOrganizations(Object.values(organizations));
+  user.organizations = await getParticipantNames(Object.values(organizations));
+  delete user.organization;
   try {
     const { rows } = await app_db_pool.query({
-      text: 'SELECT username AS id, email, created_at, first_name, last_name, country, region, is_producer, onboarding ' +
+      text: 'SELECT username AS id, email, created_at AS "createdAt", first_name AS "firstName", last_name AS "lastName", country, region, is_producer AS "isProducer", onboarding ' +
         'FROM users WHERE address = $1',
       values: [userAddress],
     });
     _.merge(user, rows[0]);
-    return res.status(200).json(format('User', user));
+    return res.status(200).json(user);
   } catch (err) {
     throw boom.badImplementation(`Failed to get profile data for user at ${userAddress}: ${err}`);
   }


### PR DESCRIPTION
- Send account details with agreement parameters (ie. if user/org type parameter, include their username/org name)
- Add new `getParticipantNames` function which replaces 2 separate `getOrganizationNames` and `getUserIds` functions.
- Remove unused `format` cases and calls
- Remove unused `getAgreementParties` function
- Add username/org name of activity instance's `completedBy` account to activity instance detailsAdd account details to agreement parameters
- Add username/org name of activity instance `completedBy` and `performer` accounts to queries

Signed-off-by: Ommi Shimizu <oshimizu15@gmail.com>

