### PR TITLE
feature/MP-409-post-formulation-cancelation

### DIFF
--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -496,7 +496,7 @@ const getAgreement = asyncMiddleware(async (req, res) => {
   let data = (await sqlCache.getAgreementData(addr, req.user.address))[0];
   if (!data) throw boom.notFound(`Agreement at ${addr} not found or user has insufficient privileges`);
   const parameters = await getAgreementParameters(addr, null);
-  const parties = await sqlCache.getAgreementParties(addr);
+  data.parties = await sqlCache.getAgreementParties(addr);
   data = format('Agreement', data);
   const documentMetadata = await sqlCache.getArchetypeDocuments(data.archetype);
   data.documents = documentMetadata.map(({ name, fileReference }) => ({ name, ...JSON.parse(fileReference) }));
@@ -506,7 +506,6 @@ const getAgreement = asyncMiddleware(async (req, res) => {
     if (id || name) withNamesObj[value] = { value, displayValue: id || name };
   });
   data.parameters = parameters.map(param => Object.assign(param, withNamesObj[param.value] || {}));
-  data.parties = parties.map(party => format('Parameter Value', party));
   data.governingAgreements = await sqlCache.getGoverningAgreements(req.params.address);
   return res.status(200).json(data);
 });

--- a/api/routes/agreements-api.js
+++ b/api/routes/agreements-api.js
@@ -593,7 +593,8 @@ module.exports = (app, customMiddleware) => {
           "address": "F8C300C2B7A3F69C90BCF97298215BA7792B2EEB",
           "signatureTimestamp": 1539260590000,
           "signedBy": "F8C300C2B7A3F69C90BCF97298215BA7792B2EEB",
-          "id": "jsmith"
+          "partyDisplayName": "jsmith",
+          "signedByDisplayName": "jsmith"
         }
     ],
     "documents": [

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -122,6 +122,14 @@
       "signatureTimestamp": {
         "name": "signature_timestamp",
         "type": "uint"
+      },
+      "canceledBy": {
+        "name": "canceled_by",
+        "type": "address"
+      },
+      "cancelationTimestamp": {
+        "name": "cancelation_timestamp",
+        "type": "uint"
       }
     }
   },

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -44,12 +44,20 @@ contract ActiveAgreement is VersionedArtifact, DataStorage, AddressScopes, Signa
 		string eventLogFileReference
 	);
 
-	event LogActiveAgreementToPartyUpdate(
+	event LogActiveAgreementToPartySignaturesUpdate(
 		bytes32 indexed eventId,
 		address agreementAddress,
 		address party,
 		address signedBy,
 		uint signatureTimestamp
+	);
+
+	event LogActiveAgreementToPartyCancelationsUpdate(
+		bytes32 indexed eventId,
+		address agreementAddress,
+		address party,
+		address canceledBy,
+		uint cancelationTimestamp
 	);
 
 	event LogGoverningAgreementUpdate(

--- a/contracts/src/agreements/DefaultActiveAgreement.sol
+++ b/contracts/src/agreements/DefaultActiveAgreement.sol
@@ -75,7 +75,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,0), AbstractDel
 			eventLogFileReference
 		);
 		for (uint i = 0; i < _parties.length; i++) {
-			emit LogActiveAgreementToPartyUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), _parties[i], address(0), uint(0));
+			emit LogActiveAgreementToPartySignaturesUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), _parties[i], address(0), uint(0));
 		}
 		for (i = 0; i < _governingAgreements.length; i++) {
 			emit LogGoverningAgreementUpdate(EVENT_ID_GOVERNING_AGREEMENT, address(this), _governingAgreements[i]);
@@ -202,7 +202,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,0), AbstractDel
 		if (signatures[party].timestamp == 0) {
 			signatures[party].signee = signee;
 			signatures[party].timestamp = block.timestamp;
-			emit LogActiveAgreementToPartyUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), party, signee, block.timestamp);
+			emit LogActiveAgreementToPartySignaturesUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), party, signee, block.timestamp);
 			if (ActiveAgreement(this).isFullyExecuted()) {
 				legalState = Agreements.LegalState.EXECUTED;
 				emit LogAgreementLegalStateUpdate(EVENT_ID_AGREEMENTS, address(this), uint8(legalState));
@@ -320,6 +320,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,0), AbstractDel
 			legalState == Agreements.LegalState.FORMULATED) {
 			// unilateral cancellation is allowed before execution phase
 			legalState = Agreements.LegalState.CANCELED;
+			emit LogActiveAgreementToPartyCancelationsUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), party, actor, block.timestamp);
 			emit LogAgreementLegalStateUpdate(EVENT_ID_AGREEMENTS, address(this), uint8(legalState));
 			emitEvent(EVENT_ID_STATE_CHANGED, this); // for cancellations we need to inform the registry
 		}
@@ -328,6 +329,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,0), AbstractDel
 			if (cancellations[party].timestamp == 0) {
 				cancellations[party].signee = actor;
 				cancellations[party].timestamp = block.timestamp;
+			  emit LogActiveAgreementToPartyCancelationsUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), party, actor, block.timestamp);
 				for (uint i=0; i<parties.length; i++) {
 					if (cancellations[parties[i]].timestamp == 0) {
 						break;


### PR DESCRIPTION
- Added cancelation details to agreement_to_party table
- Added cancelation details to GET `/agreement/:address` response obj
- Format empty activity instance `completedBy` and `performer` addresses as `null`
- Added upgrade script