### PR TITLE
Feature/MP-708 agreement attachments

### DIFF
--- a/api/common/monax-constants.js
+++ b/api/common/monax-constants.js
@@ -104,6 +104,11 @@ const NOTIFICATION = {
   ACTIVITY_INSTANCE_STATE_CHANGED: 'activityinstancestatechanged',
 };
 
+const AGREEMENT_ATTACHMENT_CONTENT_TYPES = {
+  fileReference: 'fileReference',
+  plaintext: 'plaintext',
+};
+
 module.exports = {
   MONAX_BUNDLES,
   PARAMETER_TYPES,
@@ -115,4 +120,5 @@ module.exports = {
   AGREEMENT_PARTIES,
   DEFAULT_DEPARTMENT_ID,
   NOTIFICATION,
+  AGREEMENT_ATTACHMENT_CONTENT_TYPES,
 };

--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -566,11 +566,11 @@ const updateAgreementAttachments = asyncMiddleware(async (req, res) => {
       contentType,
     });
     // Store new data in hoard
-    const hoardGrant = await hoardPut({ agreement: address, name }, JSON.stringify(attachments));
+    const hoardGrant = await hoardPut({ agreement: address, name: 'agreement_attachments.json' }, JSON.stringify(attachments));
     await contracts.updateAgreementAttachments(address, hoardGrant);
     return res.status(200).json({ attachmentsFileReference: hoardGrant, attachments });
   }
-  throw boom.badRequest(`Cannot log event. Max number of events (${data.maxNumberOfAttachments}) has been reached.`);
+  throw boom.badRequest(`Cannot add attachment. Max number of attachments (${data.maxNumberOfAttachments}) has been reached.`);
 });
 
 const signAgreement = asyncMiddleware(async (req, res) => {

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -509,15 +509,15 @@ const createAgreement = agreement => new Promise((resolve, reject) => {
       });
 });
 
-const setMaxNumberOfEvents = (agreementAddress, maxNumberOfEvents) => new Promise((resolve, reject) => {
-  log.trace(`Setting max number of events to ${maxNumberOfEvents} for agreement at ${agreementAddress}`);
+const setMaxNumberOfAttachments = (agreementAddress, maxNumberOfAttachments) => new Promise((resolve, reject) => {
+  log.trace(`Setting max number of events to ${maxNumberOfAttachments} for agreement at ${agreementAddress}`);
   appManager
     .contracts['ActiveAgreementRegistry']
-    .factory.setMaxNumberOfEvents(agreementAddress, maxNumberOfEvents, (error) => {
+    .factory.setMaxNumberOfEvents(agreementAddress, maxNumberOfAttachments, (error) => {
       if (error) {
-        return reject(boom.badImplementation(`Failed to set max number of events to ${maxNumberOfEvents} for agreement at ${agreementAddress}: ${error}`));
+        return reject(boom.badImplementation(`Failed to set max number of events to ${maxNumberOfAttachments} for agreement at ${agreementAddress}: ${error}`));
       }
-      log.info(`Set max number of events to ${maxNumberOfEvents} for agreement at ${agreementAddress}`);
+      log.info(`Set max number of events to ${maxNumberOfAttachments} for agreement at ${agreementAddress}`);
       return resolve();
     });
 });
@@ -541,15 +541,15 @@ const setAddressScopeForAgreementParameters = async (agreementAddr, parameters) 
   }
 };
 
-const updateAgreementEventLog = (agreementAddress, hoardGrant) => new Promise((resolve, reject) => {
-  log.trace(`Updating event log hoard reference for agreement at ${agreementAddress} with new hoard reference`);
+const updateAgreementAttachments = (agreementAddress, hoardGrant) => new Promise((resolve, reject) => {
+  log.trace(`Updating attachments hoard reference for agreement at ${agreementAddress} with new hoard reference ${hoardGrant}`);
   appManager
     .contracts['ActiveAgreementRegistry']
     .factory.setEventLogReference(agreementAddress, hoardGrant, (error) => {
       if (error) {
-        return reject(boom.badImplementation(`Failed to update event log for agreement at ${agreementAddress}: ${error}`));
+        return reject(boom.badImplementation(`Failed to update attachments for agreement at ${agreementAddress}: ${error}`));
       }
-      log.info(`Event log hoard reference updated for agreement at ${agreementAddress}`);
+      log.info(`Attachments hoard reference updated for agreement at ${agreementAddress}`);
       return resolve();
     });
 });
@@ -1222,7 +1222,7 @@ const getActiveAgreementData = agreementAddress => new Promise((resolve, reject)
         archetype: data.raw[0] ? data.raw[0].valueOf() : '',
         name: data.raw[1] ? global.hexToString(data.raw[1].valueOf()) : '',
         creator: data.raw[2] ? data.raw[2].valueOf() : '',
-        maxNumberOfEvents: data.raw[7] ? data.raw[7].valueOf() : '',
+        maxNumberOfAttachments: data.raw[7] ? data.raw[7].valueOf() : '',
         isPrivate: data.raw[8] ? data.raw[8].valueOf() : '',
         legalState: data.raw[9] ? data.raw[9].valueOf() : '',
         formationProcessInstance: data.raw[10] ? data.raw[10].valueOf() : '',
@@ -1259,9 +1259,9 @@ module.exports = {
   deactivateArchetypePackage,
   addArchetypeToPackage,
   createAgreement,
-  setMaxNumberOfEvents,
+  setMaxNumberOfAttachments,
   setAddressScopeForAgreementParameters,
-  updateAgreementEventLog,
+  updateAgreementAttachments,
   cancelAgreement,
   createAgreementCollection,
   addAgreementToCollection,

--- a/api/routes/agreements-api.js
+++ b/api/routes/agreements-api.js
@@ -583,6 +583,9 @@ module.exports = (app, customMiddleware) => {
     "formationProcessDefinition": "65BF0FB03BA5C140B1584A290B157F8907B8FEBE",
     "executionProcessDefinition": "E6534E45E2B26AF4FBB64E42CE7FC66688696483",
     "collectionId": "9FBC54D1E8224307DA7E74BC54D1E829764E2DE7AD0D8DF6EBC54D1E82ADBCFF",
+    "isParty": true,
+    "isCreator": true,
+    "isAssignedTask": false,
     "parties": [
         {
           "address": "F8C300C2B7A3F69C90BCF97298215BA7792B2EEB",

--- a/api/routes/agreements-api.js
+++ b/api/routes/agreements-api.js
@@ -1,3 +1,5 @@
+const multer = require('multer');
+const upload = multer();
 const {
   getArchetypes,
   getArchetype,
@@ -15,7 +17,7 @@ const {
   createAgreement,
   getAgreements,
   getAgreement,
-  updateAgreementEventLog,
+  updateAgreementAttachments,
   signAgreement,
   cancelAgreement,
   createAgreementCollection,
@@ -512,7 +514,7 @@ module.exports = (app, customMiddleware) => {
  * @apiSuccess {String} name Human readable name of the Active Agreement
  * @apiSuccess {String} archetype Address of the parent Archetype of the Active Agreement
  * @apiSuccess {Boolean} isPrivate Whether the encryption framework of the Active Agreement
- * @apiSuccess {String} eventLogFileReference Hoard grant needed to access an existing event log if any
+ * @apiSuccess {String} attachmentsFileReference Hoard grant needed to access an existing event log if any
  * @apiSuccess {Number} numberOfParties The number of parties agreeing to the Active Agreement
  * @apiSuccessExample {json} Success Objects Array
        [{
@@ -520,8 +522,8 @@ module.exports = (app, customMiddleware) => {
          "archetype": "4EF5DAB8CE089AD7F2CE7A04A7CB5DB1C58DB707",
          "name": "Drone Lease",
          "creator": "AB3399395E9CAB5434022D1992D31BB3ACC2E3F1",
-         "eventLogFileReference": "eyJTcG...iVmVyc2lvbiI6MH0=",
-         "maxNumberOfEvents": 10,
+         "attachmentsFileReference": "eyJTcG...iVmVyc2lvbiI6MH0=",
+         "maxNumberOfAttachments": 10,
          "isPrivate": 1,
          "legalState": 1,
          "formationProcessInstance": "038725D6437A809D536B9417047EC74E7FF4D1C0",
@@ -559,7 +561,7 @@ module.exports = (app, customMiddleware) => {
  * @apiSuccess {String} archetype Address of the parent Archetype of the Active Agreement
  * @apiSuccess {Boolean} isPrivate Whether the encryption framework of the Active Agreement
  * is operational or not
- * @apiSuccess {Number} maxNumberOfEvents Max number of fulfillment events that can be stored in the event log
+ * @apiSuccess {Number} maxNumberOfAttachments Max number of attachments that can be stored in the attachments
  * @apiSuccess {Number} legalState Legal state of the agreement
  * @apiSuccess {Number} formationProcessInstance Address of the agreement's formation process instance
  * @apiSuccess {Number} executionProcessInstance Address of the agreement's execution process instance
@@ -574,7 +576,7 @@ module.exports = (app, customMiddleware) => {
     "name": "Agreement",
     "archetype": "707791D3BBD4FDDE615D0EC4BB0EB3D909F66890",
     "isPrivate": false,
-    "maxNumberOfEvents": 0,
+    "maxNumberOfAttachments": 0,
     "legalState": 1,
     "formationProcessInstance": "413AC7610E6A4E0ACEB29596FFC52D243A2E7CD7",
     "executionProcessInstance": "0000000000000000000000000000000000000000",
@@ -641,7 +643,7 @@ module.exports = (app, customMiddleware) => {
  * is operational or not
  * @apiBodyParameter {String} password A secret string which is used to trigger the encryption
  * system for the Active Agreements's documents
- * @apiBodyParameter {Integer} maxNumberOfEvents The maximum number of fulfillment events to be logged on the Active Agreement
+ * @apiBodyParameter {Integer} maxNumberOfAttachments The maximum number of attachments to be logged on the Active Agreement
  * @apiBodyParameter {String[]} parties The addresses of the parties to the Active Agreement
  * @apiBodyParameter {Object[]} parameters The "custom-field-name" and values of the parameters.
  * Note- If a parameter with type 8 (Signing Party) is given, the corresponding value will be added to the agreement's parties.
@@ -654,7 +656,7 @@ module.exports = (app, customMiddleware) => {
       "archetype": "707791D3BBD4FDDE615D0EC4BB0EB3D909F66890",
       "isPrivate": false,
       "password": "secret password"
-      "maxNumberOfEvents": "10",
+      "maxNumberOfAttachments": "10",
       "parties": ["36ADA22D3A4B841EFB73414CD97C35C0A660C1C2"],
       "parameters": [{
           "name": "Buyer",
@@ -684,32 +686,46 @@ module.exports = (app, customMiddleware) => {
   app.post('/agreements', middleware, createAgreement);
 
   /**
- * @api {put} /agreements/:address/events Add a Fulfillment Event to an Agreement
- * @apiName updateAgreementEventLog
+ * @api {put} /agreements/:address/attachments Add an attachment to an Agreement
+ * @apiName updateAgreementAttachments
  * @apiGroup Agreements
+ * @apiDescription Adds an attachment to the specific agreement.
+ * When requested with `Content-Type: multipart/form-data`, the attached file will be uploaded to hoard.
+ * The attachment's content will be set to the hoard grant for the file, and the name will be set to the file's name.
+ * When requested with  `Content-Type: application/json`, the name and content from the request will be used as the attachment.
  *
  * @apiExample {curl} Simple:
- *     curl -iX POST /agreements/707791D3BBD4FDDE615D0EC4BB0EB3D909F66890/events -d '{"eventName":"eventName"}'
+ *     curl -iX POST /agreements/707791D3BBD4FDDE615D0EC4BB0EB3D909F66890/attachments -d '{"name":"name", "content":"content"}'
  *
  * @apiURLParameter address Agreement address
- * @apiBodyParameter eventName Human readable name of the fulfillment event
- * @apiBodyParameter {String} content Description of the fulfillment event
+ * @apiBodyParameter name Human readable name of the attachment
+ * @apiBodyParameter {String} content Description of the attachment
  * @apiBodyParameterExample {json} Success Object
   {
-    "eventName": "Name of Event",
-    "content": "A description about the event.",
+    "name": "Name of Attachment",
+    "content": "Content of attachment",
   }
 *
-* @apiSuccess {String} grant The hoard grant of the updated event log
+* @apiSuccess {String} attachmentsFileReference The hoard grant of the updated attachments
+* @apiSuccess {Object[]} attachments The updated array of attachments
 * @apiSuccessExample {json} Success Object
   {
-    "grant": "eyJTcG...iVmVyc2lvbiI6MH0=",
+    "attachmentsFileReference": "b9SMcG...iVmVyc2lvbiI6MH0=",
+    "attachments": [
+      {
+        "name": "Name of Attachment",
+        "submitter": "36ADA22D3A4B841EFB73414CD97C35C0A660C1C2",
+        "timestamp": 1551216868342,
+        "content": "Content of attachment",
+        "contentType": "plaintext"
+      }
+    ]
   }
 *
 * @apiUse NotLoggedIn
 * @apiUse AuthTokenRequired
 */
-  app.put('/agreements/:address/events', middleware, updateAgreementEventLog);
+  app.post('/agreements/:address/attachments', middleware, upload.any(), updateAgreementAttachments);
 
   /**
    * @api {put} /agreements Sign an Agreement

--- a/api/routes/bpm-api.js
+++ b/api/routes/bpm-api.js
@@ -450,6 +450,8 @@ module.exports = (app, customMiddleware) => {
       "modelAuthor": "5860AF129980B0E932F3509432A0C43DEAB77B0B",
       "private": 0,
       "agreementName": "Drone Lease Agreement",
+      "attachmentsFileReference": "eyJTcG...iVmVyc2lvbiI6MH0=",
+      "maxNumberOfAttachments": 10,
       "data": [
         {
           "dataMappingId": "readName",

--- a/api/schemas/agreement.js
+++ b/api/schemas/agreement.js
@@ -8,7 +8,7 @@ note- parameters are handled separately
   creator: '36ADA22D3A4B841EFB73414CD97C35C0A660C1C2',
   isPrivate: '1',
   parties: ['36ADA22D3A4B841EFB73414CD97C35C0A660C1C2'],
-  maxNumberOfEvents: 10,
+  maxNumberOfAttachments: 10,
   collectionId: 'D37EDB770A6BF4C18B3C8D37EDB770A617ED601882335549119BF4C18B3C8D37',
   governingAgreements: [
     '686b6aefa7467db432903d4fed9cd23c2ee6bd57'
@@ -36,7 +36,7 @@ const agreementSchema = Joi.object().keys({
       .max(1),
   ],
   privateParametersFileReference: Joi.string(),
-  maxNumberOfEvents: Joi.number()
+  maxNumberOfAttachments: Joi.number()
     .min(0)
     .default(0),
   parties: Joi.array()

--- a/api/test/api/api-helper.js
+++ b/api/test/api/api-helper.js
@@ -441,6 +441,49 @@ module.exports = (server) => {
       });
     },
   
+    uploadAttachmentFile: (agreement, token) => {
+      return new Promise((resolve, reject) => {
+        chai
+          .request(server)
+          .post(`/agreements/${agreement}/attachments`)
+          .set('Cookie', [`access_token=${token}`])
+          .attach('attachment', __dirname + '/web-api-test.js')
+          .end((err, res) => {
+            if (err) return reject(err);
+            if (res.status !== 200) return reject(new Error('upload attachment NOT OK'));
+            return resolve(res.body);
+          });
+      });
+    },
+  
+    uploadAttachmentObject: (agreement, attachment, token) => {
+      return new Promise((resolve, reject) => {
+        chai
+          .request(server)
+          .post(`/agreements/${agreement}/attachments`)
+          .set('Cookie', [`access_token=${token}`])
+          .send(attachment)
+          .end((err, res) => {
+            if (err) return reject(err);
+            if (res.status !== 200) return reject(new Error('upload attachment NOT OK'));
+            return resolve(res.body);
+          });
+      });
+    },
+
+    getHoard: (grant) => {
+      return new Promise((resolve, reject) => {
+        chai
+          .request(server)
+          .get(`/hoard?grant=${encodeURIComponent(grant)}`)
+          .end((err, res) => {
+            if (err) return reject(err);
+            if (res.status !== 200) return reject(new Error('hoard get NOT OK'));
+            return resolve(res.header['content-disposition']);
+          });
+      });
+    },
+
     generateModelXml: (modelId, modelPath) => {
       let xml = fs.readFileSync(path.resolve(modelPath), 'utf8');
       xml = _.replace(xml, new RegExp('###MODEL_ID###', 'g'), modelId);

--- a/api/test/api/web-api-agreements-test.js
+++ b/api/test/api/web-api-agreements-test.js
@@ -956,20 +956,19 @@ describe(':: Public/Private Agreement Parameters ::', () => {
     email: `${rid(10, 'aA0')}@test.com`,
   };
 
-  let formation = {
+  const formation = {
     filePath: 'test/data/inc-formation.bpmn',
     process: {},
     id: rid(16, 'aA0'),
     name: 'Incorporation-Formation'
-  }
-  let execution = {
+  };
+  const execution = {
     filePath: 'test/data/inc-execution.bpmn',
     process: {},
     id: rid(16, 'aA0'),
     name: 'Incorporation-Execution'
-  }
-
-  let archetype = {
+  };
+  const archetype = {
     name: 'Incorporation Archetype',
     description: 'Incorporation Archetype',
     price: 10,
@@ -990,8 +989,8 @@ describe(':: Public/Private Agreement Parameters ::', () => {
     executionProcessDefinition: '',
     formationProcessDefinition: '',
     governingArchetypes: []
-  }
-  let agreement = {
+  };
+  const agreement = {
     name: 'Pub/Priv Parameters',
     archetype: '',
     isPrivate: false,
@@ -1004,7 +1003,7 @@ describe(':: Public/Private Agreement Parameters ::', () => {
     ],
     maxNumberOfEvents: 0,
     governingAgreements: []
-  }
+  };
 
   it('Should register user', async () => {
     // REGISTER USER
@@ -1070,21 +1069,200 @@ describe(':: Public/Private Agreement Parameters ::', () => {
       }
     }, 3000);
   }).timeout(10000);
+});
 
-  it('Should have stored any parameters not used in the process models in hoard', done => {
-    // CHECK AGREEMENT PARAMETERS
+describe(':: Agreement Attachments (External References) ::', () => {
+  const user1 = {
+    username: `registeredUser${rid(5, 'aA0')}`,
+    password: 'registeredUser',
+    email: `${rid(10, 'aA0')}@test.com`,
+  };
+  const user2 = {
+    username: `registeredUser${rid(5, 'aA0')}`,
+    password: 'registeredUser',
+    email: `${rid(10, 'aA0')}@test.com`,
+  };
+
+  const formation = {
+    filePath: 'test/data/inc-formation.bpmn',
+    process: {},
+    id: rid(16, 'aA0'),
+    name: 'Incorporation-Formation'
+  }
+  const execution = {
+    filePath: 'test/data/inc-execution.bpmn',
+    process: {},
+    id: rid(16, 'aA0'),
+    name: 'Incorporation-Execution'
+  }
+
+  const archetype = {
+    name: 'Incorporation Archetype',
+    description: 'Incorporation Archetype',
+    price: 10,
+    isPrivate: 1,
+    active: 1,
+    parameters: [
+      { type: 8, name: 'Party' },
+    ],
+    documents: [],
+    jurisdictions: [],
+    executionProcessDefinition: '',
+    formationProcessDefinition: '',
+    governingArchetypes: []
+  }
+  const agreement = {
+    name: 'Attachments Agreement',
+    archetype: '',
+    isPrivate: false,
+    parameters: [],
+    maxNumberOfAttachments: 2,
+    governingAgreements: []
+  }
+
+  it('Should register users', async () => {
+    // REGISTER USERS
+    let registerResult = await api.registerUser(user1);
+    user1.address = registerResult.address;
+    expect(user1.address).to.exist
+    registerResult = await api.registerUser(user2);
+    user2.address = registerResult.address;
+    expect(user2.address).to.exist
+  }).timeout(5000);
+
+  it('Should login users', (done) => {
+    // LOGIN USERS
     setTimeout(async () => {
       try {
-        const { privateParametersFileReference } = await api.getAgreement(agreement.address, user.token);
-        let privateParameters = await api.getFromHoard(privateParametersFileReference);
-        privateParameters = JSON.parse(privateParameters);
-        expect(privateParameters.length).to.equal(2);
-        expect(privateParameters).to.deep.include(agreement.parameters[3]);
-        expect(privateParameters).to.deep.include(agreement.parameters[4]);
+        await api.activateUser(user1);
+        let loginResult = await api.loginUser(user1);
+        expect(loginResult.token).to.exist;
+        user1.token = loginResult.token;
+        await api.activateUser(user2);
+        loginResult = await api.loginUser(user2);
+        expect(loginResult.token).to.exist;
+        user2.token = loginResult.token;
         done();
       } catch (err) {
         done(err);
       }
     }, 3000);
   }).timeout(10000);
+
+  it('Should deploy formation and execution models', async () => {
+    // DEPLOY FORMATION MODEL
+    let xml = api.generateModelXml(formation.id, formation.filePath);
+    let deployed = await api.createAndDeployModel(xml, user1.token);
+    expect(deployed).to.exist;
+    archetype.formationProcessDefinition = deployed.processes[0].address;
+    expect(String(archetype.formationProcessDefinition).match(/[0-9A-Fa-f]{40}/)).to.exist;
+    // DEPLOY EXECUTION MODEL
+    xml = api.generateModelXml(execution.id, execution.filePath);
+    deployed = await api.createAndDeployModel(xml, user1.token);
+    expect(deployed).to.exist;
+    archetype.executionProcessDefinition = deployed.processes[0].address;
+    expect(String(archetype.executionProcessDefinition).match(/[0-9A-Fa-f]{40}/)).to.exist;
+  }).timeout(30000);
+
+  it('Should create an archetype', done => {
+    // CREATE ARCHETYPE
+    setTimeout(async () => {
+      try {
+        Object.assign(archetype, await api.createArchetype(archetype, user1.token));
+        expect(String(archetype.address)).match(/[0-9A-Fa-f]{40}/).to.exist;
+        agreement.archetype = archetype.address;
+        done();
+      } catch (err) {
+        done(err);
+      }
+    }, 3000);
+  }).timeout(10000);
+
+  it('Should create an agreement', done => {
+    // CREATE AGREEMENT
+    setTimeout(async () => {
+      try {
+        Object.assign(agreement, await api.createAgreement(agreement, user1.token));
+        expect(String(agreement.address)).match(/[0-9A-Fa-f]{40}/).to.exist;
+        done();
+      } catch (err) {
+        done(err);
+      }
+    }, 3000);
+  }).timeout(10000);
+
+  it('Should return an empty string for the attachments reference if not attachments have been added', done => {
+    // INITIAL ATTACHMENTS FILE REFERENCE
+    setTimeout(async () => {
+      try {
+        const { attachmentsFileReference } = await api.getAgreement(agreement.address, user1.token);
+        expect(attachmentsFileReference).to.equal('');
+        done();
+      } catch (err) {
+        done(err);
+      }
+    }, 3000);
+  }).timeout(10000);
+
+  it('Should not allow user 2 to upload an attachment to the agreement', async () => {
+    // CHECK AUTHORIZATION
+    await assert.isRejected(api.uploadAttachmentFile(agreement.address, user2.token));
+  }).timeout(10000);
+
+  let attachmentsFileReference;
+  let attachments;
+
+  it('Should allow user 1 to upload a file as an attachment to the agreement', async () => {
+    // ATTACHMENT FILE UPLOAD
+    ({ attachmentsFileReference, attachments } = await api.uploadAttachmentFile(agreement.address, user1.token));
+    expect(attachmentsFileReference).to.be.a('string');
+    expect(attachmentsFileReference).not.to.equal('');
+    expect(attachments).to.be.a('array');
+    expect(attachments.length).to.equal(1);
+    const attachment = attachments[0];
+    expect(attachment).to.be.a('object');
+    expect(attachment.name).to.equal('web-api-test.js');
+    expect(attachment.content).to.be.a('string');
+    expect(attachment.submitter).to.equal(user1.address);
+    expect(attachment.contentType).to.equal('fileReference');
+  }).timeout(10000);
+
+  it('Should allow user 1 to upload an object as an attachment to the agreement', async () => {
+    // ATTACHMENT OBJECT UPLOAD
+    const res = await api.uploadAttachmentObject(agreement.address, {
+      name: 'attachment title', content: 'attachment body',
+    }, user1.token);
+    expect(res.attachmentsFileReference).to.be.a('string');
+    expect(res.attachmentsFileReference).not.to.equal('');
+    expect(res.attachmentsFileReference).not.to.equal(attachmentsFileReference);
+    expect(res.attachments).to.be.a('array');
+    expect(res.attachments.length).to.equal(2);
+    const attachment = res.attachments[1];
+    expect(attachment).to.be.a('object');
+    expect(attachment.name).to.equal('attachment title');
+    expect(attachment.content).to.be.a('string');
+    expect(attachment.content).to.equal('attachment body');
+    expect(attachment.submitter).to.equal(user1.address);
+    expect(attachment.contentType).to.equal('plaintext');
+    attachmentsFileReference = res.attachmentsFileReference;
+  }).timeout(10000);
+
+  it("Should not allow user 1 to upload more attachments than the agreement's maxNumberOfAttachments", async () => {
+    // CHECK MAX ATTACHMENTS
+    await assert.isRejected(api.uploadAttachmentFile(agreement.address, user1.token));
+  }).timeout(10000);
+
+  it('Should allow user 1 to get attachments file from hoard', async () => {
+    // GET ATTACHMENTS
+    const contentDisposition = await api.getHoard(attachmentsFileReference);
+    console.log('****contentDisposition, ', contentDisposition);
+    expect(contentDisposition).to.equal('attachment; filename=\"agreement_attachments.json\"'); // This is the default name of the attachments file given by the API
+  }).timeout(10000);
+
+  it('Should allow user 1 to get attachment from hoard', async () => {
+    // GET ATTACHMENTS
+    const contentDisposition = await api.getHoard(attachments[0].content);
+    expect(contentDisposition).to.equal('attachment; filename=\"web-api-test.js\"'); // This is the file we are using as the attachment (see uploadAttachmentFile in api-helper)
+  }).timeout(10000);
+
 });

--- a/api/test/api/web-api-agreements-test.js
+++ b/api/test/api/web-api-agreements-test.js
@@ -299,7 +299,7 @@ describe(':: Archetype Packages and Agreement Collections ::', () => {
     isPrivate: false,
     parties: [],
     parameters: [],
-    maxNumberOfEvents: 5,
+    maxNumberOfAttachments: 5,
     governingAgreements: []
   };
   let publicPackage1 = {
@@ -493,7 +493,7 @@ describe(':: Archetype Packages and Agreement Collections ::', () => {
           isPrivate: false,
           parties: [],
           parameters: [],
-          maxNumberOfEvents: 5,
+          maxNumberOfAttachments: 5,
         }
         await assert.isRejected(api.createAgreement(agr, user1.token));
         done();
@@ -649,7 +649,7 @@ describe(':: Governing Archetypes and Agreements ::', () => {
     isPrivate: false,
     parties: [],
     parameters: [],
-    maxNumberOfEvents: 5,
+    maxNumberOfAttachments: 5,
     governingAgreements: []
   };
   let ndaAgreement = {
@@ -658,7 +658,7 @@ describe(':: Governing Archetypes and Agreements ::', () => {
     isPrivate: false,
     parties: [],
     parameters: [],
-    maxNumberOfEvents: 5,
+    maxNumberOfAttachments: 5,
     governingAgreements: []
   };
   const process1 = {};
@@ -788,7 +788,7 @@ describe(':: External Users ::', () => {
     archetype: '',
     isPrivate: false,
     parameters: [],
-    maxNumberOfEvents: 0,
+    maxNumberOfAttachments: 0,
     governingAgreements: []
   }
 

--- a/api/test/api/web-api-bpm-test.js
+++ b/api/test/api/web-api-bpm-test.js
@@ -139,7 +139,7 @@ describe(':: FORMATION - EXECUTION for Incorporation Signing and Fulfilment ::',
     archetype: '',
     isPrivate: false,
     parameters: [],
-    maxNumberOfEvents: 0,
+    maxNumberOfAttachments: 0,
     governingAgreements: []
   }
 
@@ -356,7 +356,7 @@ describe(':: FORMATION - EXECUTION for Sale of Goods User Tasks ::', () => {
     isPrivate: false,
     parties: [],
     parameters: [],
-    maxNumberOfEvents: 5,
+    maxNumberOfAttachments: 5,
     governingAgreements: []
   };
   let buyerTask;
@@ -589,7 +589,7 @@ describe(':: DATA MAPPING TEST ::', () => {
     archetype: '',
     isPrivate: false,
     parameters: [],
-    maxNumberOfEvents: 0,
+    maxNumberOfAttachments: 0,
     governingAgreements: []
   }
 
@@ -835,7 +835,7 @@ describe(':: GATEWAY TEST ::', () => {
     archetype: '',
     isPrivate: false,
     parameters: [],
-    maxNumberOfEvents: 0,
+    maxNumberOfAttachments: 0,
     governingAgreements: []
   }
 

--- a/api/test/api/web-api-test.js
+++ b/api/test/api/web-api-test.js
@@ -16,17 +16,12 @@ const log = logger.getLogger('agreements.tests');
 const api = require('./api-helper')(server)
 const { rightPad } = require(__common + '/controller-dependencies')
 
-const contracts = require(`${global.__controllers}/contracts-controller`);
-
 // configure chai
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 const should = chai.should();
 const expect = chai.expect;
 const assert = chai.assert;
-
-var hoardGrant;
-var hoardGrant2;
 
 // wait for the app to be fully bootstrapped
 before(function (done) {
@@ -269,38 +264,6 @@ describe('User Profile', () => {
     }, 3000);
   });
 });
-
-/**
- * ######## HOARD #########################################################################################
- */
-
-describe('Hoard', () => {
-  it('Should upload a real file to hoard', (done) => {
-    request(server)
-      .post('/hoard')
-      .set('Cookie', [`access_token=${token}`])
-      .attach('myfile.js', __dirname + '/web-api-test.js')
-      .expect(200)
-      .end((err, res) => {
-        if (err) return done(err)
-        hoardGrant = res.body.grant;
-        done()
-      })
-  })
-
-  it('Should upload a second real file to hoard', (done) => {
-    request(server)
-      .post('/hoard')
-      .set('Cookie', [`access_token=${token}`])
-      .attach('myfile.js', __dirname + '/../../app.js')
-      .expect(200)
-      .end((err, res) => {
-        if (err) return done(err)
-        hoardGrant2 = res.body.grant;
-        done()
-      })
-  })
-})
 
 /**
  * ######## ORGANIZATIONS #########################################################################################

--- a/api/test/controllers/contracts-test.js
+++ b/api/test/controllers/contracts-test.js
@@ -378,7 +378,7 @@ describe('CONTRACTS', () => {
   }).timeout(10000)
 
   it('Should update the event log hoard reference of an agreement', async () => {
-    await assert.isFulfilled(contracts.updateAgreementEventLog(agrAddress, 'hoard-grant'))
+    await assert.isFulfilled(contracts.updateAgreementAttachments(agrAddress, 'hoard-grant'))
   }).timeout(10000)
 
   // it('Should get activity definitions from cache', done => {

--- a/api/test/controllers/form-exec-usertask-test.js
+++ b/api/test/controllers/form-exec-usertask-test.js
@@ -142,7 +142,7 @@ describe('FORMATION - EXECUTION with 1 User Task each', () => {
       value: ''
     }
     ],
-    maxNumberOfEvents: 0
+    maxNumberOfAttachments: 0
   }
 
   it('Should create a buyer and a seller', async () => {
@@ -240,7 +240,7 @@ describe('FORMATION - EXECUTION with 1 User Task each', () => {
       archetype: agreement.archetype,
       name: agreement.name,
       creator: agreement.creator,
-      maxNumberOfEvents: 0,
+      maxNumberOfAttachments: 0,
       isPrivate: agreement.isPrivate,
       parties: [buyer.address],
       governingAgreements: []


### PR DESCRIPTION
- Rename agreement event log => attachments
-Give users assigned a task access to the agreement
- Add permissions info to GET /agreement/:address response (whether user is creator/party/current task-assignee in an agreement)
- Extend attachments endpoint to accept either plain JSON or an attached file and return file reference and attachments