### PR TITLE
Refactored the archetype documents to be stored in a Bytes32StringMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Preliminary Note
 
-While the code in this repository is geared towards its use in the [Agreements Network](https://agreements.network), the lower-level functions and smart contracts are highly reusable and suited to build any blochchain-based ecosystem application. If you would like to learn more about the interfaces used in this system please visit the [documentation site](https://docs.agreements.network) for the network.
+While the code in this repository is geared towards its use in the [Agreements Network](https://agreements.network), the lower-level functions and smart contracts are highly reusable and suited to build any blockchain-based ecosystem application. If you would like to learn more about the interfaces used in this system please visit the [documentation site](https://docs.agreements.network) for the network.
 
 To ask questions or to learn more feel free to join the [Agreements Network mailing list](https://lists.agreements.network) to ask questions or to join the community.
 

--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -123,14 +123,7 @@ const createArchetype = asyncMiddleware(async (req, res) => {
     await contracts.addArchetypeParameters(archetypeAddress, type.parameters);
   }
   if (type.documents) {
-    const docs = [];
-    type.documents.forEach((_obj) => {
-      // Set document name to hoard address
-      const obj = Object.assign({}, _obj);
-      obj.name = obj.name || `document_${Date.now()}`;
-      docs.push(obj);
-    });
-    await contracts.addArchetypeDocuments(archetypeAddress, docs);
+    await contracts.addArchetypeDocuments(archetypeAddress, type.documents);
   }
   if (type.jurisdictions) {
     await contracts.addJurisdictions(archetypeAddress, type.jurisdictions);

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -374,7 +374,7 @@ const addArchetypeDocument = (address, fileReference) => new Promise((resolve, r
     .contracts['ArchetypeRegistry']
     .factory.addDocument(address, fileReference, (error, data) => {
       if (error) {
-        return reject(boom.badImplementation(`Failed to add document to archetype at ${address}: ${error}`));
+        return reject(boomify(error, `Failed to add document to archetype ${address}`));
       }
       log.info('Added document to archetype %s', address);
       return resolve();

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -368,25 +368,23 @@ const addArchetypeParameters = (address, parameters) => new Promise((resolve, re
     });
 });
 
-const addArchetypeDocument = (address, name, fileReference) => new Promise((resolve, reject) => {
+const addArchetypeDocument = (address, fileReference) => new Promise((resolve, reject) => {
+  log.debug('Adding document to archetype %s', address);
   appManager
     .contracts['ArchetypeRegistry']
-    .factory.addDocument(address, name, fileReference, (error, data) => {
-      if (error || !data.raw) {
+    .factory.addDocument(address, fileReference, (error, data) => {
+      if (error) {
         return reject(boom.badImplementation(`Failed to add document to archetype at ${address}: ${error}`));
       }
-      if (parseInt(data.raw[0], 10) !== 1) {
-        return reject(boom.badImplementation(`Error code adding document to archetype at ${address}: ${data.raw[0]}`));
-      }
-      log.info(`Added document to archetype ${address}`);
+      log.info('Added document to archetype %s', address);
       return resolve();
     });
 });
 
 const addArchetypeDocuments = async (archetypeAddress, documents) => {
   log.trace(`Adding archetype documents to archetype at ${archetypeAddress}: ${JSON.stringify(documents.map(doc => doc.name))}`);
-  const resolvedDocs = await Promise.all(documents.map(async ({ name, grant }) => {
-    const result = await addArchetypeDocument(archetypeAddress, name, grant);
+  const resolvedDocs = await Promise.all(documents.map(async ({ grant }) => {
+    const result = await addArchetypeDocument(archetypeAddress, grant);
     return result;
   }));
   return resolvedDocs;

--- a/api/sqlsol/Tables.json
+++ b/api/sqlsol/Tables.json
@@ -376,7 +376,7 @@
       {
         "Field": "documentKey",
         "ColumnName": "document_key",
-        "Type": "string",
+        "Type": "bytes32",
         "Primary": true
       },
       {

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -57,7 +57,7 @@ contract Archetype is VersionedArtifact {
 	event LogArchetypeDocumentUpdate(
 		bytes32 indexed eventId,
 		address archetypeAddress,
-		string documentKey,
+		bytes32 documentKey,
 		string documentReference
 	);
 
@@ -95,12 +95,10 @@ contract Archetype is VersionedArtifact {
 		external;
 
 	/**
-	 * @dev Adds the document specified by the external reference to the archetype under the given name
-	 * @param _name name
+	 * @dev Adds the document specified by the external reference to this Archetype
 	 * @param _fileReference the external reference to the document
-	 * @return error code indicating success or failure
 	 */
-	function addDocument(string _name, string _fileReference) external returns (uint error);
+	function addDocument(string _fileReference) external;
 
 	/**
 	 * @dev Adds a parameter to this Archetype
@@ -140,12 +138,11 @@ contract Archetype is VersionedArtifact {
 	function getAuthor() external view returns (address author);
 
 	/**
-	 * @dev Gets document reference with given name
-	 * @param _name document name
-	 * @return error - an error code
+	 * @dev Gets document reference with given key
+	 * @param _key document key
 	 * @return fileReference - the reference to the external document
 	 */
-	function getDocument(string _name) external view returns (uint error, string fileReference);
+	function getDocument(bytes32 _key) external view returns (string fileReference);
 
 	/**
 	 * @dev Gets number of parameters
@@ -176,12 +173,11 @@ contract Archetype is VersionedArtifact {
 	function getNumberOfDocuments() external view returns (uint size);
 
 	/**
-	 * @dev Gets document name at index
+	 * @dev Returns the document key at the given index
 	 * @param _index index
-	 * @return error BaseErrors.NO_ERROR() or BaseErrors.INDEX_OUT_OF_BOUNDS() if index is out of bounds
-	 * @return name
+	 * @return key - the document key
 	 */
-	function getDocumentAtIndex(uint _index) external view returns (uint error, string name);
+	function getDocumentKeyAtIndex(uint _index) external view returns (bytes32 key);
 
 	/**
 	 * @dev Returns the number jurisdictions for this archetype

--- a/contracts/src/agreements/ArchetypeRegistry.sol
+++ b/contracts/src/agreements/ArchetypeRegistry.sol
@@ -170,11 +170,9 @@ contract ArchetypeRegistry is ObjectFactory, Upgradeable {
 	/**
 	 * @dev Adds a file reference to the given Archetype
 	 * @param _archetype archetype
-	 * @param _name name
 	 * @param _fileReference the external reference to the document
-	 * @return error BaseErrors.NO_ERROR(), BaseErrors.RESOURCE_NOT_FOUND() _archetype does not exist, or see DefaultArchetype
 	 */
-	function addDocument(address _archetype, string _name, string _fileReference) external returns (uint error);
+	function addDocument(address _archetype, string _fileReference) external;
 
 	/**
 	 * @dev Sets price of given archetype
@@ -253,74 +251,51 @@ contract ArchetypeRegistry is ObjectFactory, Upgradeable {
 	function packageHasArchetype(bytes32 _packageId, address _archetype) external view returns (bool hasArchetype);
 
 	/**
-		* @dev Gets documents size for given Archetype
-		* @param _archetype archetype
-		* @return size size
-		*/
-	function getDocumentsByArchetypeSize(address _archetype) external view returns (uint size);
-
-	/**
-		* @dev Gets document name by Archetype At index
-		* @param _archetype archetype
-		* @param _index index
-		* @return name name
-		*/
-	function getDocumentByArchetypeAtIndex(address _archetype, uint _index) external view returns (string name);
-
-	/**
-		* @dev Returns data about the document given the specified name
-		* @param _archetype archetype
-		* @param _name the document name
-		* @return fileReference - the document reference
-		*/
-	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string fileReference);
-
-	/**
-		* @dev Gets parameters size for given Archetype
-		* @param _archetype archetype
-		* @return size size
-		*/
+	 * @dev Gets parameters size for given Archetype
+	 * @param _archetype archetype
+	 * @return size size
+	 */
 	function getParametersByArchetypeSize(address _archetype) external view returns (uint size);
 
 	/**
-		* @dev Gets parameter name by Archetype At index
-		* @param _archetype archetype
-		* @param _index index
-		* @return name name
-		*/
+	 * @dev Gets parameter name by Archetype At index
+	 * @param _archetype archetype
+	 * @param _index index
+	 * @return name name
+	 */
 	function getParameterByArchetypeAtIndex(address _archetype, uint _index) external view returns (bytes32 name);
 
 	/**
-		* @dev Returns data about the parameter at with the specified name
-		* @param _archetype archetype
-		* @param _name name
-		* @return position index of parameter
-		* @return parameterType parameter type
-		*/
+	 * @dev Returns data about the parameter at with the specified name
+	 * @param _archetype archetype
+	 * @param _name name
+	 * @return position index of parameter
+	 * @return parameterType parameter type
+	 */
 	function getParameterByArchetypeData(address _archetype, bytes32 _name) external view returns (uint position, DataTypes.ParameterType parameterType);
 
 	/**
-		* @dev Returns the number of jurisdictions for the given Archetype
-		* @param _archetype archetype address
-		* @return the number of jurisdictions
-		*/
+	 * @dev Returns the number of jurisdictions for the given Archetype
+	 * @param _archetype archetype address
+	 * @return the number of jurisdictions
+	 */
 	function getNumberOfJurisdictionsForArchetype(address _archetype) external view returns (uint size);
 
 	/**
-		* @dev Returns the jurisdiction key at the specified index for the given archetype
-		* @param _archetype archetype address
-		* @param _index the index of the jurisdiction
-		* @return the jurisdiction primary key
-		*/
+	 * @dev Returns the jurisdiction key at the specified index for the given archetype
+	 * @param _archetype archetype address
+	 * @param _index the index of the jurisdiction
+	 * @return the jurisdiction primary key
+	 */
 	function getJurisdictionAtIndexForArchetype(address _archetype, uint _index) external view returns (bytes32 key);
 
 	/**
-		* @dev Returns data about the jurisdiction with the specified key in the given archetype
-		* @param _archetype archetype address
-		* @param _key the jurisdiction key
-		* @return country the jurisdiction's country
-		* @return region the jurisdiction's region
-		*/
+	 * @dev Returns data about the jurisdiction with the specified key in the given archetype
+	 * @param _archetype archetype address
+	 * @param _key the jurisdiction key
+	 * @return country the jurisdiction's country
+	 * @return region the jurisdiction's region
+	 */
 	function getJurisdictionDataForArchetype(address _archetype, bytes32 _key) external view returns (bytes2 country, bytes32 region);
 
 	/**

--- a/contracts/src/agreements/DefaultArchetypeRegistry.sol
+++ b/contracts/src/agreements/DefaultArchetypeRegistry.sol
@@ -242,15 +242,15 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 
 	/**
 	 * @dev Adds a file reference to the given Archetype
+	 * REVERTS if:
+	 * - the given archetype is not registered in this ArchetypeRegistry
 	 * @param _archetype archetype
-	 * @param _name name
 	 * @param _fileReference the external reference to the document
-	 * @return error BaseErrors.NO_ERROR(), BaseErrors.RESOURCE_NOT_FOUND() _archetype does not exist, or see DefaultArchetype
 	 */
-	function addDocument(address _archetype, string _name, string _fileReference) external returns (uint error) {
-		if (!ArchetypeRegistryDb(database).archetypeExists(_archetype))
-			return BaseErrors.RESOURCE_NOT_FOUND();
-		error = Archetype(_archetype).addDocument(_name, _fileReference);
+	function addDocument(address _archetype, string _fileReference) external {
+		ErrorsLib.revertIf(!ArchetypeRegistryDb(database).archetypeExists(_archetype),
+			ErrorsLib.RESOURCE_NOT_FOUND(), "DefaultArchetypeRegistry.addDocument", "The specified archetype address is not known to this ArchetypeRegistry");
+		Archetype(_archetype).addDocument(_fileReference);
 	}
 
 	/**
@@ -374,37 +374,6 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 				break;
 			}
 		}
-	}
-
-	/**
-	 * @dev Gets documents size for given Archetype
-	 * @param _archetype archetype
-	 * @return size size
-	 */
-	function getDocumentsByArchetypeSize(address _archetype) external view returns (uint size) {
-		return Archetype(_archetype).getNumberOfDocuments();
-	}
-
-    /**
-     * @dev Gets document name by Archetype At index
-     * @param _archetype archetype
-     * @param _index index
-     * @return name name
-     */
-	function getDocumentByArchetypeAtIndex(address _archetype, uint _index) external view returns (string name) {
-		uint error;
-		(error, name) = Archetype(_archetype).getDocumentAtIndex(_index);
-	}
-
-    /**
-     * @dev Returns data about the document at the specified address
-	 * @param _archetype archetype
-	 * @param _name the document name
-	 * @return fileReference - the document reference
-	 */
-	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string fileReference) {
-		uint error;
-		(error, fileReference) = Archetype(_archetype).getDocument(_name);
 	}
 
     /**

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -75,7 +75,6 @@ contract ActiveAgreementTest {
 	 */
 	function testActiveAgreementSigning() external returns (string) {
 
-		bool success;
 	  	ActiveAgreement agreement;
 		Archetype archetype;
 		signer1 = new DefaultUserAccount();

--- a/contracts/src/documents-commons/Documents.sol
+++ b/contracts/src/documents-commons/Documents.sol
@@ -8,11 +8,6 @@ library Documents {
 
 	// enum State {DRAFT, FINAL, EFFECTIVE, CANCELED}
 
-	struct DocumentReference {
-		string reference;
-		bool exists;
-	}
-
 	struct DocumentVersion {
 			string hash;
 			uint created;


### PR DESCRIPTION
The bytes32 key are now generated in the contract rather than passed in. This avoids someone using a filename as key and accidentally revealing information about the file's contents.

Signed-off-by: Jan Hendrik Scheufen <j.h.scheufen@gmail.com>