### PR TITLE
Agreements and archetype creation

### DIFF
--- a/api/common/aa-web-api.js
+++ b/api/common/aa-web-api.js
@@ -105,10 +105,11 @@ let app;
 
       // ERROR HANDLING MIDDLEWARE
       app.use((err, req, res, next) => {
-        log.error(err.stack);
         if (err.output) {
+          log.error(`[ ${err.output.statusCode} ${err.output.payload ? `- ${err.output.payload.error} ]` : ']'}`, err.stack);
           return res.status(err.output.statusCode).json(err.output.payload);
         }
+        log.error(err.stack);
         return res.sendStatus(500);
       });
 

--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -232,7 +232,6 @@ const createArchetype = asyncMiddleware(async (req, res) => {
     await contracts.addJurisdictions(archetypeAddress, type.jurisdictions);
   }
   await sqlCache.insertArchetypeDetails({ address: archetypeAddress, name: req.body.name, description: _.escape(req.body.description) });
-
   res.data = { archetypeAddress };
   return res
     .status(200)
@@ -399,8 +398,8 @@ const setAgreementParameters = async (agreeAddr, archAddr, parameters) => {
 };
 
 const createAgreement = asyncMiddleware(async (req, res) => {
-  let parameters = req.body.parameters || [];
-  parameters = await createOrFindAccountsWithEmails(parameters, 'type');
+  const _parameters = req.body.parameters || [];
+  const { parameters, newUsers } = await createOrFindAccountsWithEmails(_parameters, 'type');
   const parties = req.body.parties || [];
   parameters.forEach((param) => {
     if (parseInt(param.type, 10) === PARAM_TYPE.SIGNING_PARTY) parties.push(param.value);
@@ -440,7 +439,7 @@ const createAgreement = asyncMiddleware(async (req, res) => {
   await sqlCache.insertAgreementDetails({ address: agreementAddress, name: req.body.name });
   const piAddress = await contracts.startProcessFromAgreement(agreementAddress);
   log.debug(`Process Instance Address: ${piAddress}`);
-  res.data = { agreementAddress };
+  res.data = { agreementAddress, archetypeAddress: agreement.archetype, newUsers };
   res
     .status(200)
     .set('content-type', 'application/json')

--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -233,6 +233,7 @@ const createArchetype = asyncMiddleware(async (req, res) => {
   }
   await sqlCache.insertArchetypeDetails({ address: archetypeAddress, name: req.body.name, description: _.escape(req.body.description) });
 
+  res.data = { archetypeAddress };
   return res
     .status(200)
     .set('content-type', 'application/json')
@@ -439,6 +440,7 @@ const createAgreement = asyncMiddleware(async (req, res) => {
   await sqlCache.insertAgreementDetails({ address: agreementAddress, name: req.body.name });
   const piAddress = await contracts.startProcessFromAgreement(agreementAddress);
   log.debug(`Process Instance Address: ${piAddress}`);
+  res.data = { agreementAddress };
   res
     .status(200)
     .set('content-type', 'application/json')

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -42,6 +42,10 @@ let appManager;
 
 const boomify = (burrowError, message) => {
   const arr = burrowError.message ? burrowError.message.split('::') : [];
+  if (arr.length < 3) {
+    // Error is not the raw error from solidity
+    return boom.badImplementation(`${message}: ${burrowError.stack}`);
+  }
   const parsedError = {
     code: arr[0] || '',
     location: arr[1] || '',
@@ -50,23 +54,23 @@ const boomify = (burrowError, message) => {
   let error;
   switch (parsedError.code) {
     case ERR.UNAUTHORIZED:
-      error = boom.unauthorized(`${message}: ${parsedError.message}`);
+      error = boom.unauthorized(`${message}: ${parsedError.message}. ${burrowError.stack}`);
       break;
     case ERR.RESOURCE_NOT_FOUND:
-      error = boom.notFound(`${message}: ${parsedError.message}`);
+      error = boom.notFound(`${message}: ${parsedError.message}. ${burrowError.stack}`);
       break;
     case ERR.RESOURCE_ALREADY_EXISTS:
-      error = boom.conflict(`${message}: ${parsedError.message}`);
+      error = boom.conflict(`${message}: ${parsedError.message}. ${burrowError.stack}`);
       break;
     case ERR.INVALID_INPUT || ERR.INVALID_PARAMETER_STATE ||
     ERR.NULL_PARAMETER_NOT_ALLOWED || ERR.OVERWRITE_NOT_ALLOWED:
-      error = boom.badRequest(`${message}: ${parsedError.message}`);
+      error = boom.badRequest(`${message}: ${parsedError.message}. ${burrowError.stack}`);
       break;
     case ERR.RUNTIME_ERROR || ERR.INVALID_STATE || ERR.DEPENDENCY_NOT_FOUND:
-      error = boom.badImplementation(`${message}: ${parsedError.message}`);
+      error = boom.badImplementation(`${message}: ${parsedError.message}. ${burrowError.stack}`);
       break;
     default:
-      error = boom.badImplementation(`${message}: ${burrowError ? parsedError.message : 'Unknown Error'}`);
+      error = boom.badImplementation(`${message}: ${burrowError ? parsedError.message : 'Unknown Error'}. ${burrowError.stack}`);
       break;
   }
   return error;


### PR DESCRIPTION
This PR updates the agreement and archetype creation functions to return the respective addresses after creation in `res.data` such that downstream functions can perform other processing with the addresses.

It also updates the contracts-controller boomify function to handle burrow-js errors.