### PR TITLE
Feature/MP-826 archetype owner

### DIFF
--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -388,6 +388,7 @@ const createAgreement = asyncMiddleware(async (req, res, next) => {
     name: req.body.name,
     archetype: req.body.archetype,
     creator: req.user.address,
+    owner: req.body.owner || req.user.address,
     isPrivate: req.body.isPrivate,
     parties,
     collectionId: req.body.collectionId,

--- a/api/controllers/agreements-controller.js
+++ b/api/controllers/agreements-controller.js
@@ -407,6 +407,7 @@ const createAgreement = asyncMiddleware(async (req, res, next) => {
   agreement.privateParametersFileReference = await hoardPut({ name: 'privateParameters.json' }, JSON.stringify(privateParams));
   delete agreement.name; // Don't store name on chain
   const agreementAddress = await contracts.createAgreement(agreement);
+  await contracts.initializeObjectAdministrator(agreementAddress);
   await contracts.setMaxNumberOfAttachments(agreementAddress, parseInt(req.body.maxNumberOfAttachments, 10));
   await setAgreementParameters(agreementAddress, req.body.archetype, publicParams);
   await contracts.setAddressScopeForAgreementParameters(agreementAddress, parameters.filter(({ scope }) => scope));

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -521,13 +521,13 @@ const createAgreement = agreement => new Promise((resolve, reject) => {
   const {
     archetype,
     creator,
+    owner,
     privateParametersFileReference,
     parties,
     collectionId,
     governingAgreements,
   } = agreement;
   const isPrivate = agreement.isPrivate || false;
-  const owner = creator; // TODO: Owner should be received through request body
   log.trace(`Creating agreement with following data: ${JSON.stringify(agreement)}`);
   appManager
     .contracts['ActiveAgreementRegistry']

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -527,10 +527,11 @@ const createAgreement = agreement => new Promise((resolve, reject) => {
     governingAgreements,
   } = agreement;
   const isPrivate = agreement.isPrivate || false;
+  const owner = creator; // TODO: Owner should be received through request body
   log.trace(`Creating agreement with following data: ${JSON.stringify(agreement)}`);
   appManager
     .contracts['ActiveAgreementRegistry']
-    .factory.createAgreement(archetype, creator, privateParametersFileReference, isPrivate,
+    .factory.createAgreement(archetype, creator, owner, privateParametersFileReference, isPrivate,
       parties, collectionId, governingAgreements, (error, data) => {
         if (error || !data.raw) {
           return reject(boomify(error, `Failed to create agreement by ${creator} from archetype at ${agreement.archetype}`));

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -541,6 +541,17 @@ const createAgreement = agreement => new Promise((resolve, reject) => {
       });
 });
 
+const initializeObjectAdministrator = agreementAddress => new Promise((resolve, reject) => {
+  log.trace(`Initializing agreement admin role for agreement: ${agreementAddress}`);
+  const agreement = getContract(global.__abi, global.__bundles.AGREEMENTS.contracts.ACTIVE_AGREEMENT, agreementAddress);
+  agreement.initializeObjectAdministrator(serverAccount, (error) => {
+    if (error) {
+      return reject(boomify(error, `Failed to initialize object admin for agreement ${agreementAddress}`));
+    }
+    return resolve();
+  });
+});
+
 const setMaxNumberOfAttachments = (agreementAddress, maxNumberOfAttachments) => new Promise((resolve, reject) => {
   log.trace(`Setting max number of events to ${maxNumberOfAttachments} for agreement at ${agreementAddress}`);
   appManager
@@ -1368,6 +1379,7 @@ module.exports = {
   deactivateArchetypePackage,
   addArchetypeToPackage,
   createAgreement,
+  initializeObjectAdministrator,
   setMaxNumberOfAttachments,
   setAddressScopeForAgreementParameters,
   updateAgreementFileReference,

--- a/api/controllers/contracts-controller.js
+++ b/api/controllers/contracts-controller.js
@@ -262,6 +262,7 @@ const createArchetype = (type) => {
         archetype.isPrivate,
         archetype.active,
         archetype.author,
+        archetype.owner,
         archetype.formationProcessDefinition,
         archetype.executionProcessDefinition,
         archetype.packageId,

--- a/api/schemas/agreement.js
+++ b/api/schemas/agreement.js
@@ -6,6 +6,7 @@ note- parameters are handled separately
   name: 'agreement title',
   archetype: '82335549119BF4C18B3C8D37EDB770A617ED6018',
   creator: '36ADA22D3A4B841EFB73414CD97C35C0A660C1C2',
+  owner: '36ADA22D3A4B841EFB73414CD97C35C0A660C1C2',
   isPrivate: '1',
   parties: ['36ADA22D3A4B841EFB73414CD97C35C0A660C1C2'],
   maxNumberOfAttachments: 10,
@@ -26,6 +27,9 @@ const agreementSchema = Joi.object().keys({
     .hex()
     .required(),
   creator: Joi.string()
+    .hex()
+    .required(),
+  owner: Joi.string()
     .hex()
     .required(),
   isPrivate: [

--- a/api/schemas/archetype.js
+++ b/api/schemas/archetype.js
@@ -6,6 +6,7 @@ sample archetype:
 {
   name: 'archetype name',
   author: '36ADA22D3A4B841EFB73414CD97C35C0A660C1C2',
+  owner: '36ADA22D3A4B841EFB73414CD97C35C0A660C1C2',
   description: 'things about this archetype',
   isPrivate: 1,
   active: 1,
@@ -58,6 +59,9 @@ const archetypeSchema = Joi.object().keys({
     .required().max(255, 'utf8'),
   password: Joi.string().optional(),
   author: Joi.string()
+    .hex()
+    .required(),
+  owner: Joi.string()
     .hex()
     .required(),
   description: Joi.string().required(),

--- a/api/sqlsol/Tables.json
+++ b/api/sqlsol/Tables.json
@@ -268,6 +268,11 @@
         "Type": "address"
       },
       {
+        "Field": "owner",
+        "ColumnName": "owner",
+        "Type": "address"
+      },
+      {
         "Field": "active",
         "ColumnName": "active",
         "Type": "bool"

--- a/api/sqlsol/Tables.json
+++ b/api/sqlsol/Tables.json
@@ -58,6 +58,11 @@
         "Type": "address"
       },
       {
+        "Field": "owner",
+        "ColumnName": "owner",
+        "Type": "address"
+      },
+      {
         "Field": "isPrivate",
         "ColumnName": "is_private",
         "Type": "bool"

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -5,6 +5,7 @@ import "commons-collections/AddressScopes.sol";
 import "commons-events/EventEmitter.sol";
 import "documents-commons/Signable.sol";
 import "commons-management/VersionedArtifact.sol";
+import "commons-auth/Permissioned.sol";
 
 import "agreements/Agreements.sol";
 
@@ -12,7 +13,7 @@ import "agreements/Agreements.sol";
  * @title ActiveAgreement Interface
  * @dev API for interaction with an Active Agreement
  */
-contract ActiveAgreement is VersionedArtifact, DataStorage, AddressScopes, Signable, EventEmitter {
+contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, AddressScopes, Signable, EventEmitter {
 
 	event LogAgreementCreation(
 		bytes32 indexed eventId,
@@ -80,6 +81,8 @@ contract ActiveAgreement is VersionedArtifact, DataStorage, AddressScopes, Signa
 
 	// Internal EventListener event
 	bytes32 public constant EVENT_ID_STATE_CHANGED = "AGREEMENT_STATE_CHANGED";
+
+  bytes32 public constant ROLE_ID_CREATOR = keccak256(abi.encodePacked("creator"));
 
 	/**
 	 * @dev Initializes this ActiveAgreement with the provided parameters. This function replaces the

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -20,11 +20,12 @@ contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, Addres
 		address	agreementAddress,
 		address	archetypeAddress,
 		address	creator,
+		address	owner,
+		string privateParametersFileReference,
+		string eventLogFileReference,
 		bool isPrivate,
 		uint8 legalState,
-		uint32 maxEventCount,
-		string privateParametersFileReference,
-		string eventLogFileReference
+		uint32 maxEventCount
 	);
 
 	event LogAgreementLegalStateUpdate(
@@ -83,12 +84,14 @@ contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, Addres
 	bytes32 public constant EVENT_ID_STATE_CHANGED = "AGREEMENT_STATE_CHANGED";
 
   bytes32 public constant ROLE_ID_CREATOR = keccak256(abi.encodePacked("creator"));
+  bytes32 public constant ROLE_ID_OWNER = keccak256(abi.encodePacked("owner"));
 
 	/**
 	 * @dev Initializes this ActiveAgreement with the provided parameters. This function replaces the
 	 * contract constructor, so it can be used as the delegate target for an ObjectProxy.
 	 * @param _archetype archetype address
 	 * @param _creator the account that created this agreement
+	 * @param _owner the account that owns this agreement
 	 * @param _privateParametersFileReference the file reference to the private parameters
 	 * @param _isPrivate if agreement is private
 	 * @param _parties the signing parties to the agreement
@@ -97,6 +100,7 @@ contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, Addres
 	function initialize(
 		address _archetype, 
 		address _creator, 
+		address _owner, 
 		string _privateParametersFileReference, 
 		bool _isPrivate, 
 		address[] _parties, 

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -83,8 +83,8 @@ contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, Addres
 	// Internal EventListener event
 	bytes32 public constant EVENT_ID_STATE_CHANGED = "AGREEMENT_STATE_CHANGED";
 
-  bytes32 public constant ROLE_ID_CREATOR = keccak256(abi.encodePacked("creator"));
-  bytes32 public constant ROLE_ID_OWNER = keccak256(abi.encodePacked("owner"));
+  bytes32 public constant ROLE_ID_CREATOR = keccak256(abi.encodePacked("agreement.creator"));
+  bytes32 public constant ROLE_ID_OWNER = keccak256(abi.encodePacked("agreement.owner"));
 
 	/**
 	 * @dev Initializes this ActiveAgreement with the provided parameters. This function replaces the

--- a/contracts/src/agreements/ActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/ActiveAgreementRegistry.sol
@@ -49,6 +49,7 @@ contract ActiveAgreementRegistry is ObjectFactory, Upgradeable, ProcessStateChan
 	 * @dev Creates an Active Agreement with the given parameters
 	 * @param _archetype archetype
 	 * @param _creator address
+	 * @param _owner address
 	 * @param _privateParametersFileReference the file reference of the private parametes of this agreement
 	 * @param _isPrivate agreement is private
 	 * @param _parties parties array
@@ -59,6 +60,7 @@ contract ActiveAgreementRegistry is ObjectFactory, Upgradeable, ProcessStateChan
 	function createAgreement(
 		address _archetype,
 		address _creator, 
+		address _owner, 
 		string _privateParametersFileReference,
 		bool _isPrivate,
 		address[] _parties, 

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -76,8 +76,8 @@ contract Archetype is VersionedArtifact, Permissioned {
 	bytes32 public constant EVENT_ID_ARCHETYPE_JURISDICTIONS = "AN://archetypes/jurisdictions";
 	bytes32 public constant EVENT_ID_GOVERNING_ARCHETYPES = "AN://governing-archetypes";
 
-  bytes32 public constant ROLE_ID_AUTHOR = keccak256(abi.encodePacked("author"));
-  bytes32 public constant ROLE_ID_OWNER = keccak256(abi.encodePacked("owner"));
+  bytes32 public constant ROLE_ID_AUTHOR = keccak256(abi.encodePacked("archetype.author"));
+  bytes32 public constant ROLE_ID_OWNER = keccak256(abi.encodePacked("archetype.owner"));
 
 	/**
 	 * @dev Initializes this ActiveAgreement with the provided parameters. This function replaces the

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -2,19 +2,21 @@ pragma solidity ^0.4.25;
 
 import "commons-utils/DataTypes.sol";
 import "commons-management/VersionedArtifact.sol";
+import "commons-auth/Permissioned.sol";
 
 
 /**
  * @title Archetype Interface
  * @dev API for interaction with an agreement archetype
  */
-contract Archetype is VersionedArtifact {
+contract Archetype is VersionedArtifact, Permissioned {
 
 	event LogArchetypeCreation(
 		bytes32 indexed eventId,
 		address archetypeAddress,
 		uint price,
 		address author,
+		address owner,
 		bool active,
 		bool isPrivate,
 		address successor,
@@ -74,6 +76,9 @@ contract Archetype is VersionedArtifact {
 	bytes32 public constant EVENT_ID_ARCHETYPE_JURISDICTIONS = "AN://archetypes/jurisdictions";
 	bytes32 public constant EVENT_ID_GOVERNING_ARCHETYPES = "AN://governing-archetypes";
 
+  bytes32 public constant ROLE_ID_AUTHOR = keccak256(abi.encodePacked("author"));
+  bytes32 public constant ROLE_ID_OWNER = keccak256(abi.encodePacked("owner"));
+
 	/**
 	 * @dev Initializes this ActiveAgreement with the provided parameters. This function replaces the
 	 * contract constructor, so it can be used as the delegate target for an ObjectProxy.
@@ -89,6 +94,7 @@ contract Archetype is VersionedArtifact {
 		bool _isPrivate,
 		bool _active,
 		address _author,
+		address _owner,
 		address _formationProcess,
 		address _executionProcess,
 		address[] _governingArchetypes)
@@ -136,6 +142,12 @@ contract Archetype is VersionedArtifact {
 	 * @return author author
 	 */
 	function getAuthor() external view returns (address author);
+
+	/**
+	 * @dev Gets Owner
+	 * @return owner owner
+	 */
+	function getOwner() external view returns (address owner);
 
 	/**
 	 * @dev Gets document reference with given key

--- a/contracts/src/agreements/ArchetypeRegistry.sol
+++ b/contracts/src/agreements/ArchetypeRegistry.sol
@@ -41,6 +41,7 @@ contract ArchetypeRegistry is ObjectFactory, Upgradeable {
 	/**
 	 * @dev Creates a new archetype
 	 * @param _author author
+	 * @param _owner owner
 	 * @param _price price
 	 * @param _isPrivate determines if the archetype's documents are encrypted
 	 * @param _active determines if this archetype is active
@@ -56,6 +57,7 @@ contract ArchetypeRegistry is ObjectFactory, Upgradeable {
 		bool _isPrivate, 
 		bool _active, 
 		address _author, 
+		address _owner, 
 		address _formationProcess, 
 		address _executionProcess, 
 		bytes32 _packageId, 
@@ -151,6 +153,7 @@ contract ArchetypeRegistry is ObjectFactory, Upgradeable {
 		* @param _archetype the archetype address
 		* @return price price
 		* @return author author address
+		* @return owner owner address
 		* @return active bool
 		* @return isPrivate bool
 		* @return successor address
@@ -160,6 +163,7 @@ contract ArchetypeRegistry is ObjectFactory, Upgradeable {
 	function getArchetypeData(address _archetype) external view returns (
 		uint price,
 		address author,
+		address owner,
 		bool active,
 		bool isPrivate,
 		address successor,

--- a/contracts/src/agreements/DefaultActiveAgreement.sol
+++ b/contracts/src/agreements/DefaultActiveAgreement.sol
@@ -17,7 +17,7 @@ import "agreements/AgreementsAPI.sol";
 import "agreements/Archetype.sol";
 import "agreements/ActiveAgreement.sol";
 
-contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,1), AbstractDelegateTarget, AbstractPermissioned, AbstractDataStorage, AbstractAddressScopes, DefaultEventEmitter, ActiveAgreement {
+contract DefaultActiveAgreement is AbstractVersionedArtifact(1,1,0), AbstractDelegateTarget, AbstractPermissioned, AbstractDataStorage, AbstractAddressScopes, DefaultEventEmitter, ActiveAgreement {
 	
 	using ArrayUtilsLib for address[];
 	using TypeUtilsLib for bytes32;
@@ -44,6 +44,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,1), AbstractDel
 	 * contract constructor, so it can be used as the delegate target for an ObjectProxy.
 	 * @param _archetype archetype address
 	 * @param _creator the account that created this agreement
+	 * @param _owner the account that owns this agreement
 	 * @param _privateParametersFileReference the file reference to the private parameters (optional)
 	 * @param _isPrivate if agreement is private
 	 * @param _parties the signing parties to the agreement
@@ -52,6 +53,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,1), AbstractDel
 	function initialize(
 		address _archetype, 
 		address _creator, 
+		address _owner, 
 		string _privateParametersFileReference, 
 		bool _isPrivate, 
 		address[] _parties, 
@@ -82,16 +84,23 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,0,1), AbstractDel
     permissions[ROLE_ID_CREATOR].transferable = false;
     permissions[ROLE_ID_CREATOR].exists = true;
 
+    permissions[ROLE_ID_OWNER].holders.push(_owner);
+    permissions[ROLE_ID_OWNER].multiHolder = false;
+    permissions[ROLE_ID_OWNER].revocable = false;
+    permissions[ROLE_ID_OWNER].transferable = true;
+    permissions[ROLE_ID_OWNER].exists = true;
+
 		emit LogAgreementCreation(
 			EVENT_ID_AGREEMENTS,
 			address(this),
 			_archetype,
 			_creator,
+      _owner,
+			_privateParametersFileReference,
+			"",
 			_isPrivate,
 			uint8(legalState),
-			maxNumberOfEvents,
-			_privateParametersFileReference,
-			""
+			maxNumberOfEvents
 		);
 		for (uint i = 0; i < _parties.length; i++) {
 			emit LogActiveAgreementToPartySignaturesUpdate(EVENT_ID_AGREEMENT_PARTY_MAP, address(this), _parties[i], address(0), uint(0));

--- a/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
@@ -27,7 +27,7 @@ import "agreements/ArchetypeRegistry.sol";
  * @title DefaultActiveAgreementRegistry Interface
  * @dev A contract interface to create and manage Active Agreements.
  */
-contract DefaultActiveAgreementRegistry is AbstractVersionedArtifact(1,0,1), AbstractObjectFactory, ArtifactsFinderEnabled, AbstractEventListener, AbstractDbUpgradeable, ActiveAgreementRegistry {
+contract DefaultActiveAgreementRegistry is AbstractVersionedArtifact(1,1,0), AbstractObjectFactory, ArtifactsFinderEnabled, AbstractEventListener, AbstractDbUpgradeable, ActiveAgreementRegistry {
 
 	using ArrayUtilsLib for address[];
 
@@ -63,6 +63,7 @@ contract DefaultActiveAgreementRegistry is AbstractVersionedArtifact(1,0,1), Abs
 	 * @dev Creates an Active Agreement with the given parameters
 	 * @param _archetype archetype
 	 * @param _creator address
+	 * @param _owner address
 	 * @param _privateParametersFileReference the file reference of the private parametes of this agreement
 	 * @param _isPrivate agreement is private
 	 * @param _parties parties array
@@ -78,6 +79,7 @@ contract DefaultActiveAgreementRegistry is AbstractVersionedArtifact(1,0,1), Abs
 	function createAgreement(
 		address _archetype,
 		address _creator, 
+		address _owner, 
 		string _privateParametersFileReference,
 		bool _isPrivate, 
 		address[] _parties, 
@@ -87,7 +89,7 @@ contract DefaultActiveAgreementRegistry is AbstractVersionedArtifact(1,0,1), Abs
 	{
     agreementAddress = new ObjectProxy(artifactsFinder, OBJECT_CLASS_AGREEMENT);
 		ActiveAgreement agreement = ActiveAgreement(agreementAddress);
-    agreement.initialize(_archetype, _creator, _privateParametersFileReference, _isPrivate, _parties, _governingAgreements);
+    agreement.initialize(_archetype, _creator, _owner, _privateParametersFileReference, _isPrivate, _parties, _governingAgreements);
 		uint error = ActiveAgreementRegistryDb(database).registerActiveAgreement(agreementAddress);
 		ErrorsLib.revertIf(error != BaseErrors.NO_ERROR(),
 			ErrorsLib.RESOURCE_ALREADY_EXISTS(), "DefaultActiveAgreementRegistry.createAgreement", "Active Agreement already exists");

--- a/contracts/src/agreements/DefaultArchetype.sol
+++ b/contracts/src/agreements/DefaultArchetype.sol
@@ -18,7 +18,7 @@ import "agreements/Archetype.sol";
  * @title DefaultArchetype
  * @dev Default agreements network archetype
  */
-contract DefaultArchetype is AbstractVersionedArtifact(1,0,0), AbstractDelegateTarget, AbstractPermissioned, Archetype {
+contract DefaultArchetype is AbstractVersionedArtifact(1,1,0), AbstractDelegateTarget, AbstractPermissioned, Archetype {
 
 	using ArrayUtilsLib for bytes32[];
 	using ArrayUtilsLib for address[];

--- a/contracts/src/agreements/DefaultArchetypeRegistry.sol
+++ b/contracts/src/agreements/DefaultArchetypeRegistry.sol
@@ -25,6 +25,7 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 	/**
 	 * @dev Creates a new archetype
 	 * @param _author author
+	 * @param _owner owner
 	 * @param _price price
 	 * @param _isPrivate determines if the archetype's documents are encrypted
 	 * @param _active determines if this archetype is active
@@ -40,6 +41,7 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 		bool _isPrivate, 
 		bool _active, 
 		address _author,
+		address _owner,
 		address _formationProcess, 
 		address _executionProcess, 
 		bytes32 _packageId, 
@@ -50,7 +52,7 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 		ErrorsLib.revertIf(_author == 0x0,
 			ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultArchetypeRegistry.createArchetype", "Archetype author address must not be empty");
 		archetype = new ObjectProxy(artifactsFinder, OBJECT_CLASS_ARCHETYPE);
-		Archetype(archetype).initialize(_price, _isPrivate, _active, _author,  _formationProcess, _executionProcess, _governingArchetypes);
+		Archetype(archetype).initialize(_price, _isPrivate, _active, _author, _owner, _formationProcess, _executionProcess, _governingArchetypes);
 		// since this is a newly created archetype address, we can safely ignore the return value of the DB.addArchetype() function
 		ArchetypeRegistryDb(database).addArchetype(archetype);
 		if (_packageId != "")
@@ -223,6 +225,7 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 	function getArchetypeData(address _archetype) external view returns (
 		uint price,
 		address author,
+		address owner,
 		bool active,
 		bool isPrivate,
 		address successor,
@@ -232,6 +235,7 @@ contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractO
 		if (ArchetypeRegistryDb(database).archetypeExists(_archetype)) {
 			price = Archetype(_archetype).getPrice();
 			author = Archetype(_archetype).getAuthor();
+			owner = Archetype(_archetype).getOwner();
 			active = Archetype(_archetype).isActive();
 			isPrivate = Archetype(_archetype).isPrivate();
 			successor = Archetype(_archetype).getSuccessor();

--- a/contracts/src/agreements/DefaultArchetypeRegistry.sol
+++ b/contracts/src/agreements/DefaultArchetypeRegistry.sol
@@ -20,7 +20,7 @@ import "agreements/Agreements.sol";
  * @title DefaultArchetypeRegistry
  * @dev Creates and tracks archetypes
  */
-contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,0,0), AbstractObjectFactory, ArtifactsFinderEnabled, AbstractDbUpgradeable, ArchetypeRegistry {
+contract DefaultArchetypeRegistry is AbstractVersionedArtifact(1,1,0), AbstractObjectFactory, ArtifactsFinderEnabled, AbstractDbUpgradeable, ArchetypeRegistry {
 	
 	/**
 	 * @dev Creates a new archetype

--- a/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
@@ -19,7 +19,7 @@ contract ActiveAgreementRegistryTest {
 
 	string constant SUCCESS = "success";
 	bytes32 EMPTY = "";
-	string constant functionRegistryCreateAgreement = "createAgreement(address,address,string,bool,address[],bytes32,address[])";
+	string constant functionRegistryCreateAgreement = "createAgreement(address,address,address,string,bool,address[],bytes32,address[])";
 	string constant functionRegistryAddAgreementToCollection = "addAgreementToCollection(bytes32,address)";
 	string constant functionRegistryAddArchetypeToPackage = "addArchetypeToPackage(bytes32,address)";
 	
@@ -107,7 +107,7 @@ contract ActiveAgreementRegistryTest {
 				return "Expected error NULL_PARAM_NOT_ALLOWED for empty archetype address";
 		}
 
-		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
+		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, address(this), address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		if (activeAgreement == address(0)) return "Agreement creation returned empty address";
 
 		if (agreementRegistry.getActiveAgreementAtIndex(0) != activeAgreement) return "ActiveAgreement at index 0 not as expected";
@@ -143,7 +143,7 @@ contract ActiveAgreementRegistryTest {
 		archetypeAddr = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		if (archetypeAddr == address(0)) return "Archetype creation returned empty address";
 
-		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
+		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, address(this), address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		if (activeAgreement == address(0)) return "Agreement creation returned empty address";
 
 		if (address(agreementRegistry).call(abi.encodeWithSignature(functionRegistryAddAgreementToCollection, fakeCollectionId, activeAgreement))) {
@@ -187,7 +187,7 @@ contract ActiveAgreementRegistryTest {
 		
 		if (agreementRegistry.getNumberOfAgreementCollections() != 2) return "Registry should have 2 collections";
 
-		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, address(this), dummyPrivateParametersFileRef, false, parties, leaseCollectionId2, emptyArray);
+		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, address(this), address(this), dummyPrivateParametersFileRef, false, parties, leaseCollectionId2, emptyArray);
 		if (activeAgreement2 == address(0)) return "Failed to create a second agreement to put into lease collection 2";
 
 		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 2) return "Lease collection 2 should now have 2 agreements";
@@ -204,7 +204,7 @@ contract ActiveAgreementRegistryTest {
 
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype does not have a governing employmentArchetype should fail
 		ndaArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
-		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
+		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(employmentAgreement);
 		if (address(agreementRegistry).call(abi.encodeWithSignature(functionRegistryCreateAgreement,
 			ndaArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements))) {
@@ -222,7 +222,7 @@ contract ActiveAgreementRegistryTest {
 
 		// trying to create a ndaAgreement with a unrelated governing agreement when the ndaArchetype has a governing employmentArchetype should fail
 		benefitsArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
-		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
+		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(benefitsAgreement);
 		if (address(agreementRegistry).call(abi.encodeWithSignature(functionRegistryCreateAgreement,
 			ndaArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements))) {
@@ -232,7 +232,7 @@ contract ActiveAgreementRegistryTest {
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype has a governing employmentArchetype should pass
 		governingAgreements.length = 0;
 		governingAgreements.push(employmentAgreement);
-		ndaAgreement = agreementRegistry.createAgreement(ndaArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements);
+		ndaAgreement = agreementRegistry.createAgreement(ndaArchetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements);
 		if (ndaAgreement == address(0)) return "Failed to create ndaAgreement with expected governing agreement employmentAgreement";
 		
 		return SUCCESS;

--- a/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
@@ -100,7 +100,7 @@ contract ActiveAgreementRegistryTest {
 
 		ActiveAgreementRegistry agreementRegistry = createNewAgreementRegistry();
 
-    	archetypeAddr = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+    	archetypeAddr = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 
 		if (address(agreementRegistry).call(functionRegistryCreateAgreement, 
 			address(0), address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray)) {
@@ -140,7 +140,7 @@ contract ActiveAgreementRegistryTest {
 
 		ActiveAgreementRegistry agreementRegistry = createNewAgreementRegistry();
 	
-		archetypeAddr = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetypeAddr = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		if (archetypeAddr == address(0)) return "Archetype creation returned empty address";
 
 		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
@@ -200,10 +200,10 @@ contract ActiveAgreementRegistryTest {
 		
 		ActiveAgreementRegistry agreementRegistry = createNewAgreementRegistry();
 
-		employmentArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		employmentArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype does not have a governing employmentArchetype should fail
-		ndaArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		ndaArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(employmentAgreement);
 		if (address(agreementRegistry).call(abi.encodeWithSignature(functionRegistryCreateAgreement,
@@ -214,14 +214,14 @@ contract ActiveAgreementRegistryTest {
 		// trying to create a ndaAgreement with no governing employmentAgreement when the ndaArchetype has a governing employmentArchetype should fail
 		governingArchetypes.push(employmentArchetype);
 		governingAgreements.length = 0;
-		ndaArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, governingArchetypes);
+		ndaArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, governingArchetypes);
 		if (address(agreementRegistry).call(abi.encodeWithSignature(functionRegistryCreateAgreement,
 			ndaArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements))) {
 				return "Expected failure when creating agreement with governing agreements when its archetype has no governing archetypes";
 		}
 
 		// trying to create a ndaAgreement with a unrelated governing agreement when the ndaArchetype has a governing employmentArchetype should fail
-		benefitsArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		benefitsArchetype = archetypeRegistry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, address(this), dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(benefitsAgreement);
 		if (address(agreementRegistry).call(abi.encodeWithSignature(functionRegistryCreateAgreement,

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -49,7 +49,7 @@ contract ActiveAgreementTest {
 		parties.push(address(signer2));
 
 		archetype = new DefaultArchetype();
-		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, emptyArray);
+		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, emptyArray);
 		agreement = new DefaultActiveAgreement();
 		agreement.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 		agreement.setEventLogReference(dummyFileRef);
@@ -102,7 +102,7 @@ contract ActiveAgreementTest {
 		parties.push(address(org1));
 
 		archetype = new DefaultArchetype();
-		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, emptyArray);
+		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, emptyArray);
 		agreement = new DefaultActiveAgreement();
 		agreement.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 
@@ -157,7 +157,7 @@ contract ActiveAgreementTest {
 		parties.push(address(signer2));
 
 		archetype = new DefaultArchetype();
-		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, emptyArray);
+		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, emptyArray);
 		agreement1 = new DefaultActiveAgreement();
 		agreement1.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 		agreement2 = new DefaultActiveAgreement();

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -51,7 +51,7 @@ contract ActiveAgreementTest {
 		archetype = new DefaultArchetype();
 		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, emptyArray);
 		agreement = new DefaultActiveAgreement();
-		agreement.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
+		agreement.initialize(archetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 		agreement.setEventLogReference(dummyFileRef);
 		if (keccak256(abi.encodePacked(agreement.getEventLogReference())) != keccak256(abi.encodePacked(dummyFileRef)))
 			return "The EventLog file reference was not set/retrieved correctly";
@@ -104,7 +104,7 @@ contract ActiveAgreementTest {
 		archetype = new DefaultArchetype();
 		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, emptyArray);
 		agreement = new DefaultActiveAgreement();
-		agreement.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
+		agreement.initialize(archetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 
 		// test signing
 		address signee;
@@ -159,9 +159,9 @@ contract ActiveAgreementTest {
 		archetype = new DefaultArchetype();
 		archetype.initialize(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, emptyArray);
 		agreement1 = new DefaultActiveAgreement();
-		agreement1.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
+		agreement1.initialize(archetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 		agreement2 = new DefaultActiveAgreement();
-		agreement2.initialize(archetype, address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
+		agreement2.initialize(archetype, address(this), address(this), dummyPrivateParametersFileRef, false, parties, emptyArray);
 
 		// test invalid cancellation and states
 		if (address(agreement1).call(bytes4(keccak256(abi.encodePacked("cancel()")))))

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -176,7 +176,7 @@ contract ActiveAgreementWorkflowTest {
 		agreementRegistry = createNewAgreementRegistry();
 
 		// make an agreement with fields of type address and add role qualifiers.
-		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(0), address(0), EMPTY, governingArchetypes);
+		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), address(0), address(0), EMPTY, governingArchetypes);
 		ActiveAgreement agreement = new DefaultActiveAgreement();
 		agreement.initialize(addr, address(this), "", false, parties, governingAgreements);
 		agreement.setDataValueAsBytes32("AgreementRoleField43", "SellerRole");
@@ -265,7 +265,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// COMBO 1: Formation, but no execution
 		//
-		addr = archetypeRegistry.createArchetype(10, false, true, address(this), formationPD, address(0), EMPTY, governingArchetypes);
+		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), formationPD, address(0), EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo1Archetype, address is empty";
 		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements));
 		(error, addr) = agreementRegistry.startProcessLifecycle(ActiveAgreement(agreement));
@@ -276,7 +276,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// COMBO 2: Execution, but no formation
 		//
-		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(0), executionPD, EMPTY, governingArchetypes);
+		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), address(0), executionPD, EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo2Archetype, address is empty";
 		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements));
 		// First try fail, because agreement is not executed
@@ -290,7 +290,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// COMBO 1: No formation, no execution
 		//
-		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(0), address(0), EMPTY, governingArchetypes);
+		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), address(0), address(0), EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo3Archetype, address is empty";
 		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements));
 		(error, addr) = agreementRegistry.startProcessLifecycle(ActiveAgreement(agreement));
@@ -376,7 +376,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// ARCHETYPE
 		//
-		addr = archetypeRegistry.createArchetype(10, false, true, address(this), formationPD, executionPD, EMPTY, governingArchetypes);
+		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), formationPD, executionPD, EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating TestArchetype, address is empty";
 
 		//
@@ -507,7 +507,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// ARCHETYPE
 		//
-		addr = archetypeRegistry.createArchetype(10, false, true, address(this), formationPD, executionPD, EMPTY, governingArchetypes);
+		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), formationPD, executionPD, EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating TestArchetype, address is empty";
 
 		//

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -178,7 +178,7 @@ contract ActiveAgreementWorkflowTest {
 		// make an agreement with fields of type address and add role qualifiers.
 		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), address(0), address(0), EMPTY, governingArchetypes);
 		ActiveAgreement agreement = new DefaultActiveAgreement();
-		agreement.initialize(addr, address(this), "", false, parties, governingAgreements);
+		agreement.initialize(addr, address(this), address(this), "", false, parties, governingAgreements);
 		agreement.setDataValueAsBytes32("AgreementRoleField43", "SellerRole");
 		// Adding two scopes to the agreement:
 		// 1. Buyer context: a fixed scope for the msg.sender
@@ -267,7 +267,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), formationPD, address(0), EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo1Archetype, address is empty";
-		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements));
+		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), address(this), "", false, parties, EMPTY, governingAgreements));
 		(error, addr) = agreementRegistry.startProcessLifecycle(ActiveAgreement(agreement));
 		if (error != BaseErrors.NO_ERROR()) return "Error starting formation / no execution combo";
 		if (addr == address(0)) return "Starting formation / no execution combo should return a PI address for formation";
@@ -278,7 +278,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), address(0), executionPD, EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo2Archetype, address is empty";
-		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements));
+		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), address(this), "", false, parties, EMPTY, governingAgreements));
 		// First try fail, because agreement is not executed
 		if (address(agreementRegistry).call(abi.encodeWithSignature("startProcessLifecycle(address)", address(agreement)))) return "Starting no formation / execution combo with a non-executed agreement should fail ";
 		agreement.sign();
@@ -292,7 +292,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		addr = archetypeRegistry.createArchetype(10, false, true, address(this), address(this), address(0), address(0), EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo3Archetype, address is empty";
-		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements));
+		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, address(this), address(this), "", false, parties, EMPTY, governingAgreements));
 		(error, addr) = agreementRegistry.startProcessLifecycle(ActiveAgreement(agreement));
 		if (error != 0) return "Expected empty error code starting no formation / no execution combo";
 		if (addr != address(0)) return "Expected no address starting no formation / no execution combo";
@@ -382,7 +382,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// AGREEMENT
 		//
-		address agreement = agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements);
+		address agreement = agreementRegistry.createAgreement(addr, address(this), address(this), "", false, parties, EMPTY, governingAgreements);
 		// Org2 has a department, so we're setting the additional context on the agreement
 		ActiveAgreement(agreement).setAddressScope(address(org2), DATA_FIELD_AGREEMENT_PARTIES, departmentId1, EMPTY, EMPTY, 0x0);
 		//TODO we currently don't support a negotiation phase in the AN, so the agreement's prose contract is already formulated when the agreement is created.
@@ -515,9 +515,9 @@ contract ActiveAgreementWorkflowTest {
 		//
 		address agreement1;
 		address agreement2;
-		agreement1 = agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements);
+		agreement1 = agreementRegistry.createAgreement(addr, address(this), address(this), "", false, parties, EMPTY, governingAgreements);
 		if (agreement1 == 0x0) return "Unexpected error creating agreement1";
-		agreement2 = agreementRegistry.createAgreement(addr, address(this), "", false, parties, EMPTY, governingAgreements);
+		agreement2 = agreementRegistry.createAgreement(addr, address(this), address(this), "", false, parties, EMPTY, governingAgreements);
 		if (agreement2 == 0x0) return "Unexpected error creating agreement2";
 
 		//

--- a/contracts/src/agreements/test/ArchetypeRegistryTest.sol
+++ b/contracts/src/agreements/test/ArchetypeRegistryTest.sol
@@ -18,7 +18,7 @@ contract ArchetypeRegistryTest {
 	string constant SUCCESS = "success";
 	bytes32 EMPTY = "";
 	string constant functionRegistryAddArchetypeToPackage = "addArchetypeToPackage(bytes32,address)";
-	string constant functionRegistryCreateArchetype = "createArchetype(uint,bool,bool,address,address,address,bytes32,address[])";
+	string constant functionRegistryCreateArchetype = "createArchetype(uint,bool,bool,address,address,address,address,bytes32,address[])";
 	string constant functionRegistryCreateArchetypePackage = "createArchetypePackage(address,bool,bool)";
 	string constant functionRegistryAddDocument = "addDocument(address,string)";
 
@@ -80,12 +80,12 @@ contract ArchetypeRegistryTest {
 		uint error;
 
 		if (address(registry).call(abi.encodeWithSignature(functionRegistryCreateArchetype,
-			0, false, true, address(0), address(0), address(0), EMPTY, addrArrayWithDupes)))
+			0, false, true, address(0), address(0), address(0), address(0), EMPTY, addrArrayWithDupes)))
 		{
 			return "Creating archetype with empty author expected to fail";
 		}
 
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
 		if (archetype == address(0)) return "Archetype address is empty after creation";
 
 		if (registry.getArchetypesSize() != 1) return "Exp. 1";
@@ -96,6 +96,9 @@ contract ArchetypeRegistryTest {
 
 		registry.deactivate(archetype, falseAddress);
 		if (Archetype(archetype).isActive()) return "Archetype should be deactivated";
+
+		if (Archetype(archetype).getAuthor() != falseAddress) return "Archetype author should be returned";
+		if (Archetype(archetype).getOwner() != falseAddress) return "Archetype owner should be returned";
 
 		// Parameter
 
@@ -171,10 +174,10 @@ contract ArchetypeRegistryTest {
 
 		address successor;
 
-		droneArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
+		droneArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
 		if (droneArchetype == address(0)) return "droneArchetype address empty after creation";
 
-		droneArchetype2 = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
+		droneArchetype2 = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
 		if (droneArchetype2 == address(0)) return "droneArchetype2 address empty after creation";
 
 		registry.setArchetypeSuccessor(droneArchetype, droneArchetype2, falseAddress);
@@ -197,7 +200,7 @@ contract ArchetypeRegistryTest {
 			return "Creating an archetype package with an empty author should revert";
 		}
 
-		droneArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
+		droneArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithDupes);
 		if (droneArchetype == address(0)) return "droneArchetype address empty after creation";
 
 		if (address(registry).call(abi.encodeWithSignature(functionRegistryAddArchetypeToPackage, fakePackageId, droneArchetype))) {
@@ -227,7 +230,7 @@ contract ArchetypeRegistryTest {
 		if (registry.getNumberOfArchetypesInPackage(dronePackageId) != 1) return "Drone package should have 1 archetype";
 		if (registry.getArchetypeAtIndexInPackage(dronePackageId, 0) != droneArchetype) return "Archetype at index 0 should match droneArchetype";
 
-		droneArchetype2 = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, dronePackageId, addrArrayWithDupes);
+		droneArchetype2 = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, dronePackageId, addrArrayWithDupes);
 
 		if (registry.getNumberOfArchetypesInPackage(dronePackageId) != 2) return "Drone package should have 2 archetypes";
 		if (registry.getArchetypeAtIndexInPackage(dronePackageId, 1) != droneArchetype2) return "Archetype at index 1 should match droneArchetype2";
@@ -241,14 +244,14 @@ contract ArchetypeRegistryTest {
 
 		address archetype;
 
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		addrArrayWithDupes.push(archetype);
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		addrArrayWithDupes.push(archetype);
 		addrArrayWithDupes.push(archetype); // duplicate
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		addrArrayWithDupes.push(archetype);
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		addrArrayWithDupes.push(archetype);
 		
 		if (address(registry).call(abi.encodeWithSignature("createArchetype(uint,bool,bool,address,address,address,bytes32,address[])", 
@@ -256,21 +259,21 @@ contract ArchetypeRegistryTest {
 				return "Creating archetype with duplicate governing archetypes should fail";
 		}
 
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		addrArrayWithoutDupes.push(archetype);
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, emptyArray);
 		addrArrayWithoutDupes.push(archetype);
-		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithoutDupes);
+		archetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, addrArrayWithoutDupes);
 		if (archetype == address(0)) return "Archetype with no duplicate gov archetypes has no address";
 
 		// Create employment archetype
-		employmentArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, ndaGovArchetypes);
+		employmentArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, ndaGovArchetypes);
 		if (archetype == address(0)) return "Employment archetype created with no errors, but empty address returned";
 
 		ndaGovArchetypes.push(employmentArchetype);
 
 		// Create NDA Archetype with employment archetype as its governing archetype
-		ndaArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, EMPTY, ndaGovArchetypes);
+		ndaArchetype = registry.createArchetype(10, false, true, falseAddress, falseAddress, falseAddress, falseAddress, EMPTY, ndaGovArchetypes);
 		if (archetype == address(0)) return "NDA archetype creation returned empty address";
 
 		if (registry.getNumberOfGoverningArchetypes(ndaArchetype) != 1) return "ndaArchetype should have 1 governing archetype";

--- a/contracts/src/build-test-commons-auth.yaml
+++ b/contracts/src/build-test-commons-auth.yaml
@@ -17,6 +17,9 @@ jobs:
   - name: UserAccountTest
     build:
       contract: commons-auth/test/UserAccountTest.sol
+  - name: PermissionedTest
+    build:
+      contract: commons-auth/test/PermissionedTest.sol
   - name: ParticipantsManagerTest
     build:
       contract: commons-auth/test/ParticipantsManagerTest.sol

--- a/contracts/src/commons-auth/AbstractPermissioned.sol
+++ b/contracts/src/commons-auth/AbstractPermissioned.sol
@@ -61,7 +61,7 @@ contract AbstractPermissioned is Permissioned {
      * @param _permission the permission identifier
      * @param _multiHolder determines whether the permission can be granted to multiple people at the same time
      * @param _revocable determines whether the permission can be revoked by the permission administrator
-     * @param _transferable determines whether holders of the permission is allowed to transfer their grant to someone else
+     * @param _transferable determines whether holders of the permission are allowed to transfer their grant to someone else
      */
     function createPermission(bytes32 _permission, bool _multiHolder, bool _revocable, bool _transferable)
         external

--- a/contracts/src/commons-auth/AbstractPermissioned.sol
+++ b/contracts/src/commons-auth/AbstractPermissioned.sol
@@ -30,8 +30,9 @@ contract AbstractPermissioned is Permissioned {
         _;
     }
 
-    constructor() internal {
-        permissions[ROLE_ID_PERMISSION_ADMIN].holders.push(msg.sender);
+    // this will allow the agreement to set the creator as admin without having the registry have to transfer it afterwards!
+    constructor(address _admin) internal {
+        permissions[ROLE_ID_PERMISSION_ADMIN].holders.push(_admin == address(0) ? msg.sender : _admin);
         permissions[ROLE_ID_PERMISSION_ADMIN].multiHolder = true;
         permissions[ROLE_ID_PERMISSION_ADMIN].revocable = false;
         permissions[ROLE_ID_PERMISSION_ADMIN].transferable = true;
@@ -84,6 +85,8 @@ contract AbstractPermissioned is Permissioned {
     function transferPermission(string _permission, address _newHolder)
         external
     {
+		// TODO, if perm is multiholder, then transferPermission needs to check if the new holder is already a holder!
+
         ErrorsLib.revertIf(!permissions[_permission].exists,
             ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.transferPermission", "The specified permission does not exist. Create it first.");
         ErrorsLib.revertIf(!permissions[_permission].transferable,

--- a/contracts/src/commons-auth/AbstractPermissioned.sol
+++ b/contracts/src/commons-auth/AbstractPermissioned.sol
@@ -93,23 +93,9 @@ contract AbstractPermissioned is Permissioned {
         ErrorsLib.revertIf(!permissions[_permission].exists,
             ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.grantPermission", "The specified permission does not exist. Create it first.");
         if (permissions[_permission].multiHolder) {
-            // look for empty slots from previous deletions and if the new holder is already registered
-            bool alreadyHasPermission;
-            uint emptySlotIndex = uint(-1); //NOTE: using uint(-1) to signal "no empty slots" would not work if an array of holders were ever be filled to the max.
-            for (uint i=0; i<permissions[_permission].holders.length; i++) {
-                if (permissions[_permission].holders[i] == _newHolder) {
-                    alreadyHasPermission = true;
-                }
-                if (permissions[_permission].holders[i] == address(0) && emptySlotIndex == uint(-1)) {
-                    emptySlotIndex = i;
-                }
-            }
-            if (!alreadyHasPermission) {
-                if (emptySlotIndex == uint(-1))
-                    permissions[_permission].holders.push(_newHolder);
-                else
-                    permissions[_permission].holders[emptySlotIndex] = _newHolder;
-            }
+            // check if the new holder is already registered
+            if (!permissions[_permission].holders.contains(_newHolder))
+                permissions[_permission].holders.push(_newHolder);
         }
         // a single-held permission that has already been granted cannot be overwritten here. Use transferPermission(...)!
         else if (permissions[_permission].holders[0] == address(0)) {

--- a/contracts/src/commons-auth/AbstractPermissioned.sol
+++ b/contracts/src/commons-auth/AbstractPermissioned.sol
@@ -1,38 +1,18 @@
 pragma solidity ^0.4.25;
 
 import "commons-base/ErrorsLib.sol";
-import "commons-utils/ArrayUtilsAPI.sol";
+import "commons-utils/ArrayUtilsLib.sol";
 import "commons-auth/Permissioned.sol";
 
 /**
- *
+ * @title AbstractPermissioned
+ * @dev Abstract implementation of the Permissioned interface
  */
 contract AbstractPermissioned is Permissioned {
 
-    using ArrayUtilsAPI for address[];
+    using ArrayUtilsLib for address[];
 
     string public constant ROLE_ID_PERMISSION_ADMIN = "permission.admin";
-
-    constructor() internal {
-        permissions[ROLE_ID_PERMISSION_ADMIN].holders[0] = msg.sender;
-        permissions[ROLE_ID_PERMISSION_ADMIN].multiHolder = true;
-        permissions[ROLE_ID_PERMISSION_ADMIN].revocable = false;
-        permissions[ROLE_ID_PERMISSION_ADMIN].transferable = true;
-        permissions[ROLE_ID_PERMISSION_ADMIN].exists = true;
-    }
-
-    modifier pre_requiresPermission(string _permission) {
-        bool accessGranted;
-        if (permissions[_permission].exists) {
-            accessGranted = permissions[_permission].multiHolder ?
-                permissions[_permission].holders.contains(msg.sender) :
-                (permissions[_permission].holders.length > 0 &&
-                 permissions[_permission].holders[0] == msg.sender);
-        }
-        ErrorsLib.revertIf(!accessGranted,
-            ErrorsLib.UNAUTHORIZED(), "AbstractPermissioned.pre_requiresPermission", "The msg.sender does not have the required permission");
-        _;
-    }
 
     struct Permission {
         address[] holders;
@@ -44,13 +24,49 @@ contract AbstractPermissioned is Permissioned {
 
     mapping(string => Permission) permissions;
 
-    function grantPermission(string _permission, address _holder)
+    modifier pre_requiresPermission(string _permission) {
+        ErrorsLib.revertIf(!hasPermission(_permission, msg.sender),
+            ErrorsLib.UNAUTHORIZED(), "AbstractPermissioned.pre_requiresPermission", "The msg.sender does not have the required permission");
+        _;
+    }
+
+    constructor() internal {
+        permissions[ROLE_ID_PERMISSION_ADMIN].holders.push(msg.sender);
+        permissions[ROLE_ID_PERMISSION_ADMIN].multiHolder = true;
+        permissions[ROLE_ID_PERMISSION_ADMIN].revocable = false;
+        permissions[ROLE_ID_PERMISSION_ADMIN].transferable = true;
+        permissions[ROLE_ID_PERMISSION_ADMIN].exists = true;
+    }
+
+    function grantPermission(string _permission, address _newHolder)
         external
         pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
     {
         ErrorsLib.revertIf(!permissions[_permission].exists,
-            ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.grantPermission", "Specified permission does not exist");
-
+            ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.grantPermission", "The specified permission does not exist. Create it first.");
+        if (permissions[_permission].multiHolder) {
+            // look for empty slots from previous deletions and if the new holder is already registered
+            bool alreadyHasPermission;
+            uint emptySlotIndex = uint(-1); //NOTE: using uint(-1) to signal "no empty slots" would not work if an array of holders were ever be filled to the max.
+            for (uint i=0; i<permissions[_permission].holders.length; i++) {
+                if (permissions[_permission].holders[i] == _newHolder) {
+                    alreadyHasPermission = true;
+                }
+                if (permissions[_permission].holders[i] == address(0) && emptySlotIndex == uint(-1)) {
+                    emptySlotIndex = i;
+                }
+            }
+            if (!alreadyHasPermission) {
+                if (emptySlotIndex == uint(-1))
+                    permissions[_permission].holders.push(_newHolder);
+                else
+                    permissions[_permission].holders[emptySlotIndex] = _newHolder;
+            }
+        }
+        // a single-held permission that has already been granted cannot be overwritten here. Use transferPermission.
+        else if (permissions[_permission].holders[0] == address(0)) {
+            permissions[_permission].holders[0] = _newHolder;
+        }
     }
 
     function createPermission(string _permission, bool _multiHolder, bool _revocable, bool _transferable)
@@ -58,7 +74,7 @@ contract AbstractPermissioned is Permissioned {
         pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
     {
         ErrorsLib.revertIf(permissions[_permission].exists,
-            ErrorsLib.RESOURCE_ALREADY_EXISTS(), "AbstractPermissioned.createPermission", "A permissions with the same name already exists");
+            ErrorsLib.RESOURCE_ALREADY_EXISTS(), "AbstractPermissioned.createPermission", "A permission with the identifier name already exists");
         permissions[_permission].multiHolder = _multiHolder;
         permissions[_permission].revocable = _revocable;
         permissions[_permission].transferable = _transferable;
@@ -68,13 +84,50 @@ contract AbstractPermissioned is Permissioned {
     function transferPermission(string _permission, address _newHolder)
         external
     {
-
+        ErrorsLib.revertIf(!permissions[_permission].exists,
+            ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.transferPermission", "The specified permission does not exist. Create it first.");
+        ErrorsLib.revertIf(!permissions[_permission].transferable,
+            ErrorsLib.INVALID_STATE(), "AbstractPermissioned.transferPermission", "The specified permission is not transferable");
+        // to transfer a permission, it does not matter whether it's multi-holder or not.
+        for (uint i=0; i<permissions[_permission].holders.length; i++) {
+            if (permissions[_permission].holders[i] == msg.sender) {
+                // we don't shift an entries in the array to fill the empty slot here, but instead try to re-use empty slots when permissions are granted
+                permissions[_permission].holders[i] = _newHolder;
+                return;
+            }
+        }
+        revert(ErrorsLib.format(ErrorsLib.UNAUTHORIZED(), "AbstractPermissioned.transferPermission", "The msg.sender does not hold the specified permission"));
     }
 
     function revokePermission(string _permission, address _holder)
         external
+        pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
     {
+        ErrorsLib.revertIf(!permissions[_permission].exists,
+            ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.revokePermission", "The specified permission does not exist. Create it first.");
+        ErrorsLib.revertIf(!permissions[_permission].revocable,
+            ErrorsLib.INVALID_STATE(), "AbstractPermissioned.revokePermission", "The specified permission is not revocable");
+        if (permissions[_permission].multiHolder) {
+            for (uint i=0; i<permissions[_permission].holders.length; i++) {
+                if (permissions[_permission].holders[i] == _holder) {
+                    delete permissions[_permission].holders[i];
+                    return;
+                }
+            }
+        }
+        else {
+            delete permissions[_permission].holders[0];
+        }
+        // for multiholder ??? leave slot empty and fill it on the next grantPermission? or shift all array entries?
+    }
 
+    function hasPermission(string _permission, address _holder) public view returns (bool result) {
+        if (permissions[_permission].exists) {
+            result = permissions[_permission].multiHolder ?
+                permissions[_permission].holders.contains(_holder) :
+                (permissions[_permission].holders.length > 0 &&
+                 permissions[_permission].holders[0] == _holder);
+        }
     }
 
 }

--- a/contracts/src/commons-auth/AbstractPermissioned.sol
+++ b/contracts/src/commons-auth/AbstractPermissioned.sol
@@ -1,0 +1,80 @@
+pragma solidity ^0.4.25;
+
+import "commons-base/ErrorsLib.sol";
+import "commons-utils/ArrayUtilsAPI.sol";
+import "commons-auth/Permissioned.sol";
+
+/**
+ *
+ */
+contract AbstractPermissioned is Permissioned {
+
+    using ArrayUtilsAPI for address[];
+
+    string public constant ROLE_ID_PERMISSION_ADMIN = "permission.admin";
+
+    constructor() internal {
+        permissions[ROLE_ID_PERMISSION_ADMIN].holders[0] = msg.sender;
+        permissions[ROLE_ID_PERMISSION_ADMIN].multiHolder = true;
+        permissions[ROLE_ID_PERMISSION_ADMIN].revocable = false;
+        permissions[ROLE_ID_PERMISSION_ADMIN].transferable = true;
+        permissions[ROLE_ID_PERMISSION_ADMIN].exists = true;
+    }
+
+    modifier pre_requiresPermission(string _permission) {
+        bool accessGranted;
+        if (permissions[_permission].exists) {
+            accessGranted = permissions[_permission].multiHolder ?
+                permissions[_permission].holders.contains(msg.sender) :
+                (permissions[_permission].holders.length > 0 &&
+                 permissions[_permission].holders[0] == msg.sender);
+        }
+        ErrorsLib.revertIf(!accessGranted,
+            ErrorsLib.UNAUTHORIZED(), "AbstractPermissioned.pre_requiresPermission", "The msg.sender does not have the required permission");
+        _;
+    }
+
+    struct Permission {
+        address[] holders;
+        bool multiHolder;
+        bool revocable;
+        bool transferable;
+        bool exists;
+    }
+
+    mapping(string => Permission) permissions;
+
+    function grantPermission(string _permission, address _holder)
+        external
+        pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+    {
+        ErrorsLib.revertIf(!permissions[_permission].exists,
+            ErrorsLib.RESOURCE_NOT_FOUND(), "AbstractPermissioned.grantPermission", "Specified permission does not exist");
+
+    }
+
+    function createPermission(string _permission, bool _multiHolder, bool _revocable, bool _transferable)
+        external
+        pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+    {
+        ErrorsLib.revertIf(permissions[_permission].exists,
+            ErrorsLib.RESOURCE_ALREADY_EXISTS(), "AbstractPermissioned.createPermission", "A permissions with the same name already exists");
+        permissions[_permission].multiHolder = _multiHolder;
+        permissions[_permission].revocable = _revocable;
+        permissions[_permission].transferable = _transferable;
+        permissions[_permission].exists = true;
+    }
+
+    function transferPermission(string _permission, address _newHolder)
+        external
+    {
+
+    }
+
+    function revokePermission(string _permission, address _holder)
+        external
+    {
+
+    }
+
+}

--- a/contracts/src/commons-auth/AbstractPermissioned.sol
+++ b/contracts/src/commons-auth/AbstractPermissioned.sol
@@ -12,7 +12,7 @@ contract AbstractPermissioned is Permissioned {
 
     using ArrayUtilsLib for address[];
 
-    string public constant ROLE_ID_PERMISSION_ADMIN = "permission.admin";
+    bytes32 public constant ROLE_ID_PERMISSION_ADMIN = keccak256(abi.encodePacked("permission.admin"));
 
     struct Permission {
         address[] holders;
@@ -22,9 +22,9 @@ contract AbstractPermissioned is Permissioned {
         bool exists;
     }
 
-    mapping(string => Permission) permissions;
+    mapping(bytes32 => Permission) permissions;
 
-    modifier pre_requiresPermission(string _permission) {
+    modifier pre_requiresPermission(bytes32 _permission) {
         ErrorsLib.revertIf(!hasPermission(_permission, msg.sender),
             ErrorsLib.UNAUTHORIZED(), "AbstractPermissioned.pre_requiresPermission", "The msg.sender does not have the required permission");
         _;
@@ -39,7 +39,7 @@ contract AbstractPermissioned is Permissioned {
         permissions[ROLE_ID_PERMISSION_ADMIN].exists = true;
     }
 
-    function grantPermission(string _permission, address _newHolder)
+    function grantPermission(bytes32 _permission, address _newHolder)
         external
         pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
     {
@@ -70,7 +70,7 @@ contract AbstractPermissioned is Permissioned {
         }
     }
 
-    function createPermission(string _permission, bool _multiHolder, bool _revocable, bool _transferable)
+    function createPermission(bytes32 _permission, bool _multiHolder, bool _revocable, bool _transferable)
         external
         pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
     {
@@ -82,7 +82,7 @@ contract AbstractPermissioned is Permissioned {
         permissions[_permission].exists = true;
     }
 
-    function transferPermission(string _permission, address _newHolder)
+    function transferPermission(bytes32 _permission, address _newHolder)
         external
     {
 		// TODO, if perm is multiholder, then transferPermission needs to check if the new holder is already a holder!
@@ -102,7 +102,7 @@ contract AbstractPermissioned is Permissioned {
         revert(ErrorsLib.format(ErrorsLib.UNAUTHORIZED(), "AbstractPermissioned.transferPermission", "The msg.sender does not hold the specified permission"));
     }
 
-    function revokePermission(string _permission, address _holder)
+    function revokePermission(bytes32 _permission, address _holder)
         external
         pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
     {
@@ -124,7 +124,7 @@ contract AbstractPermissioned is Permissioned {
         // for multiholder ??? leave slot empty and fill it on the next grantPermission? or shift all array entries?
     }
 
-    function hasPermission(string _permission, address _holder) public view returns (bool result) {
+    function hasPermission(bytes32 _permission, address _holder) public view returns (bool result) {
         if (permissions[_permission].exists) {
             result = permissions[_permission].multiHolder ?
                 permissions[_permission].holders.contains(_holder) :

--- a/contracts/src/commons-auth/Permissioned.sol
+++ b/contracts/src/commons-auth/Permissioned.sol
@@ -2,20 +2,20 @@ pragma solidity ^0.4.25;
 
 /**
  * @title Permissioned Interface
- * A contract with string-based permissioning capabilities.
+ * A contract with permissioning capabilities.
  */
 contract Permissioned {
 
     //TODO events?
 
-    function grantPermission(string _permission, address _holder) external;
+    function grantPermission(bytes32 _permission, address _holder) external;
 
-    function createPermission(string _permission, bool _multiHolder, bool _revocable, bool _transferable) external;
+    function createPermission(bytes32 _permission, bool _multiHolder, bool _revocable, bool _transferable) external;
 
-    function transferPermission(string _permission, address _newHolder) external;
+    function transferPermission(bytes32 _permission, address _newHolder) external;
 
-    function revokePermission(string _permission, address _holder) external;
+    function revokePermission(bytes32 _permission, address _holder) external;
 
-    function hasPermission(string _permission, address _holder) public view returns (bool);
+    function hasPermission(bytes32 _permission, address _holder) public view returns (bool);
 
 }

--- a/contracts/src/commons-auth/Permissioned.sol
+++ b/contracts/src/commons-auth/Permissioned.sol
@@ -8,6 +8,8 @@ contract Permissioned {
 
     //TODO events?
 
+    function initializeObjectAdministrator(address _admin) public;
+
     function createPermission(bytes32 _permission, bool _multiHolder, bool _revocable, bool _transferable) external;
 
     function grantPermission(bytes32 _permission, address _holder) external;

--- a/contracts/src/commons-auth/Permissioned.sol
+++ b/contracts/src/commons-auth/Permissioned.sol
@@ -8,9 +8,9 @@ contract Permissioned {
 
     //TODO events?
 
-    function grantPermission(bytes32 _permission, address _holder) external;
-
     function createPermission(bytes32 _permission, bool _multiHolder, bool _revocable, bool _transferable) external;
+
+    function grantPermission(bytes32 _permission, address _holder) external;
 
     function transferPermission(bytes32 _permission, address _newHolder) external;
 

--- a/contracts/src/commons-auth/Permissioned.sol
+++ b/contracts/src/commons-auth/Permissioned.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.25;
+
+import "commons-auth/Permissioned.sol";
+
+/**
+ * @title Permissioned Interface
+ * A contract with string-based permissioning capabilities.
+ */
+contract Permissioned {
+
+    //TODO events?
+
+    function grantPermission(string _permission, address _holder) external;
+
+    function createPermission(string _permission, bool _multiHolder, bool _revocable, bool _transferable) external;
+
+    function transferPermission(string _permission, address _newHolder) external;
+
+    function revokePermission(string _permission, address _holder) external;
+
+}

--- a/contracts/src/commons-auth/Permissioned.sol
+++ b/contracts/src/commons-auth/Permissioned.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.4.25;
 
-import "commons-auth/Permissioned.sol";
-
 /**
  * @title Permissioned Interface
  * A contract with string-based permissioning capabilities.
@@ -17,5 +15,7 @@ contract Permissioned {
     function transferPermission(string _permission, address _newHolder) external;
 
     function revokePermission(string _permission, address _holder) external;
+
+    function hasPermission(string _permission, address _holder) public view returns (bool);
 
 }

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -7,15 +7,50 @@ contract PermissionedTest {
 	
 	string constant SUCCESS = "success";
 
+	string constant permission1 = "test.permission1";
+	string constant permission2 = "test.permission2";
+	string constant permission3 = "test.permission3";
+
+	string constant functionSigCreatePermission = "createPermission(string,bool,bool,bool)";
+	string constant functionSigGrantPermission = "grantPermission(string,address)";
+	string constant functionSigRevokePermission = "revokePermission(string,address)";
+	string constant functionSigTransferPermission = "transferPermission(string,address)";
+
 	/**
 	 * @dev Tests the functions of a Permissioned contract
 	 */
 	function testPermissions() external returns (string) {
 
-		PermissionedObject object = new PermissionedObject(msg.sender);
-		if (!object.hasPermission(object.ROLE_ID_PERMISSION_ADMIN(), address(this))) return "The test contract should be the permission admin first";
-		object.transferPermission(object.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
-		if (!object.hasPermission(object.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The msg.sender should be the permission admin after transfer";
+		// Make a permissioned object with no pre-determined admin
+		PermissionedObject object1 = new PermissionedObject(address(0));
+		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), address(this))) return "The test contract should be the admin";
+
+		// verify function signatures are all working before testing revert scenarios!
+		if (!address(object1).call(abi.encodeWithSignature(functionSigCreatePermission,
+			permission1, true, true, true))) return "functionSigCreatePermission should work in call()";
+		if (!address(object1).call(abi.encodeWithSignature(functionSigGrantPermission,
+			permission1, address(this)))) return "functionSigGrantPermission should work in call()";
+		if (!address(object1).call(abi.encodeWithSignature(functionSigTransferPermission,
+			permission1, msg.sender))) return "functionSigTransferPermission should work in call()";
+		if (!address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
+			permission1, msg.sender))) return "functionSigRevokePermission should work in call()";
+
+
+
+		if (address(object1).call(abi.encodeWithSignature(functionSigCreatePermission,
+			permission1, true, false, false))) return "Creating a permission that already exists should revert";
+
+
+
+		object1.transferPermission(object1.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
+		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The msg.sender should be the admin after transfer from test contract";
+
+		// Make a permissioned object with pre-determined admin
+		PermissionedObject object2 = new PermissionedObject(msg.sender);
+		if (!object2.hasPermission(object2.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The test msg.sender should be the admin";
+		// test function accessibility only by admin
+		if (address(object2).call(abi.encodeWithSignature(functionSigCreatePermission,
+			permission1, true, true, true))) return "Creating a permission without the admin role should revert";
 
 		return SUCCESS;
 	}
@@ -26,7 +61,7 @@ contract PermissionedObject is AbstractPermissioned {
 
 	address creator;
 
-	constructor(address _creator) public {
+	constructor(address _creator) AbstractPermissioned(_creator) public {
 		creator = _creator;
 	}
 }

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -7,14 +7,14 @@ contract PermissionedTest {
 	
 	string constant SUCCESS = "success";
 
-	string constant permission1 = "test.permission1";
-	string constant permission2 = "test.permission2";
-	string constant permission3 = "test.permission3";
+	bytes32 constant permission1 = "test.permission1";
+	bytes32 constant permission2 = "test.permission2";
+	bytes32 constant permission3 = "test.permission3";
 
-	string constant functionSigCreatePermission = "createPermission(string,bool,bool,bool)";
-	string constant functionSigGrantPermission = "grantPermission(string,address)";
-	string constant functionSigRevokePermission = "revokePermission(string,address)";
-	string constant functionSigTransferPermission = "transferPermission(string,address)";
+	string constant functionSigCreatePermission = "createPermission(bytes32,bool,bool,bool)";
+	string constant functionSigGrantPermission = "grantPermission(bytes32,address)";
+	string constant functionSigRevokePermission = "revokePermission(bytes32,address)";
+	string constant functionSigTransferPermission = "transferPermission(bytes32,address)";
 
 	/**
 	 * @dev Tests the functions of a Permissioned contract

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -43,6 +43,8 @@ contract PermissionedTest {
     // Create and set up more permissions with different attributes
 		object1.createPermission(permission2, true, false, false);
 		object1.grantPermission(permission2, address(this));
+		object1.createPermission(permission3, false, false, false);
+		object1.grantPermission(permission3, address(this));
 
     // Make another permissioned object and permissions for testing pre_requiresPermission
 		PermissionedObject object3 = new PermissionedObject(address(this));
@@ -65,11 +67,14 @@ contract PermissionedTest {
     /* grantPermission
       1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
       2. Permission does not exist
+      3. Overwritting an already-granted single-holder permission
     */
     if (address(object3).call(abi.encodeWithSignature(functionSigGrantPermission,
 			permission1, msg.sender))) return "Granting a permission without the admin role should revert";
     if (address(object1).call(abi.encodeWithSignature(functionSigGrantPermission,
 			"fakePermission", msg.sender))) return "Granting a non-existent permission should revert";
+    if (address(object1).call(abi.encodeWithSignature(functionSigGrantPermission,
+			permission3, msg.sender))) return "Re-granting a single-holder permission should revert";
 
     /* transferPermission
       1. Permission does not exist
@@ -96,11 +101,13 @@ contract PermissionedTest {
       4. Permission is not held by specified account
     */
     if (address(object3).call(abi.encodeWithSignature(functionSigRevokePermission,
-			permission2, msg.sender))) return "Revoking a permission without the admin role should revert";
+			permission2, msg.sender))) return "Revoking another account's permission without the admin role should revert";
   	if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
 			"fakePermission", msg.sender))) return "Revoking a non-existent permission should revert";
 		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
 			permission2, address(this)))) return "Revoking a non-revocable permission should revert";
+		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
+			object1.ROLE_ID_PERMISSION_ADMIN(), address(this)))) return "Revoking the admin permission from the only holder should revert";
 		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
 			permission1, msg.sender))) return "Revoking a permission from an account that doesn't hold the permission should revert";
 

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -24,7 +24,11 @@ contract PermissionedTest {
 
 		// Make a permissioned object with no pre-determined admin
 		PermissionedObject object1 = new PermissionedObject(address(0));
-		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), address(this))) return "The test contract should be the admin";
+		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), address(this))) return "The test contract should be the admin for object1";
+
+		// Make a permissioned object with pre-determined admin
+		PermissionedObject object2 = new PermissionedObject(msg.sender);
+		if (!object2.hasPermission(object2.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The test msg.sender should be the admin for object2";
 
 		// verify function signatures are all working before testing revert scenarios!
 		if (!address(object1).call(abi.encodeWithSignature(functionSigCreatePermission,
@@ -36,31 +40,84 @@ contract PermissionedTest {
 		if (!address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
 			permission1, msg.sender))) return "functionSigRevokePermission should work in call()";
 
-		if (address(object1).call(abi.encodeWithSignature(functionSigCreatePermission,
+    // Create and set up more permissions with different attributes
+		object1.createPermission(permission2, true, false, false);
+		object1.grantPermission(permission2, address(this));
+
+    // Make another permissioned object and permissions for testing pre_requiresPermission
+		PermissionedObject object3 = new PermissionedObject(address(this));
+		object3.createPermission(permission1, true, true, true);
+		object3.createPermission(permission2, true, true, true);
+		object3.grantPermission(permission2, msg.sender);
+		object3.transferPermission(object3.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
+
+    // Revert Scenarios:
+
+    /* createPermission
+      1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+      2. Permission already exists
+    */
+    if (address(object3).call(abi.encodeWithSignature(functionSigCreatePermission,
+			permission1, true, true, true))) return "Creating a permission without the admin role should revert";
+    if (address(object1).call(abi.encodeWithSignature(functionSigCreatePermission,
 			permission1, true, false, false))) return "Creating a permission that already exists should revert";
-		if (address(object1).call(abi.encodeWithSignature(functionSigGrantPermission,
+
+    /* grantPermission
+      1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+      2. Permission does not exist
+    */
+    if (address(object3).call(abi.encodeWithSignature(functionSigGrantPermission,
+			permission1, msg.sender))) return "Granting a permission without the admin role should revert";
+    if (address(object1).call(abi.encodeWithSignature(functionSigGrantPermission,
 			"fakePermission", msg.sender))) return "Granting a non-existent permission should revert";
 
-		// Create various multi-holder permissions and test
-		object1.createPermission(permission2, true, false, true);
-		object1.createPermission(permission3, true, false, false);
+    /* transferPermission
+      1. Permission does not exist
+      2. Permission is not transferable
+      3. msg.sender does not hold the specified permission
+      4. Permission is already held by specified account
+    */
+		if (address(object1).call(abi.encodeWithSignature(functionSigTransferPermission,
+			"fakePermission", msg.sender))) return "Transfering a non-existant permission should revert";
+		if (address(object1).call(abi.encodeWithSignature(functionSigTransferPermission,
+			permission2, msg.sender))) return "Transfering a non-transferable permission should revert";
+    object1.grantPermission(permission1, msg.sender);
+		if (address(object1).call(abi.encodeWithSignature(functionSigTransferPermission,
+			permission1, address(this)))) return "Transfering a permission from an account that does not hold the permission should revert";
+    object1.revokePermission(permission1, msg.sender);
+    object1.grantPermission(permission1, address(this));
+		if (address(object1).call(abi.encodeWithSignature(functionSigTransferPermission,
+			permission1, address(this)))) return "Transfering a permission to an account already holding the permission should revert";
 
+    /* revokePermission
+      1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+      2. Permission does not exist
+      3. Permission is not revocable
+      4. Permission is not held by specified account
+    */
+    if (address(object3).call(abi.encodeWithSignature(functionSigRevokePermission,
+			permission2, msg.sender))) return "Revoking a permission without the admin role should revert";
+  	if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
+			"fakePermission", msg.sender))) return "Revoking a non-existent permission should revert";
+		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
+			permission2, address(this)))) return "Revoking a non-revocable permission should revert";
+		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
+			permission1, msg.sender))) return "Revoking a permission from an account that doesn't hold the permission should revert";
+
+		// Test various multi-holder permissions
+		if (!object1.hasPermission(permission1, address(this))) return "Test contract should have permission1 on object1";
 		if (object1.hasPermission(permission1, msg.sender)) return "msg.sender should not have permission1 on object1";
 		object1.grantPermission(permission1, msg.sender);
 		if (!object1.hasPermission(permission1, msg.sender)) return "msg.sender should have permission1 on object1";
-
-
+		object1.revokePermission(permission1, msg.sender);
+		if (object1.hasPermission(permission1, msg.sender)) return "msg.sender should have had permission1 on object1 revoked from them";
+		object1.transferPermission(permission1, msg.sender);
+		if (!object1.hasPermission(permission1, msg.sender)) return "msg.sender should have had permission1 on object1 transfered to them";
+		if (object1.hasPermission(permission1, address(this))) return "Test contract should have had permission1 on object1 transfered from them";
 
 		// Test transfer of permission admin role
 		object1.transferPermission(object1.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
 		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The msg.sender should be the admin after transfer from test contract";
-
-		// Make a permissioned object with pre-determined admin
-		PermissionedObject object2 = new PermissionedObject(msg.sender);
-		if (!object2.hasPermission(object2.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The test msg.sender should be the admin";
-		// test function accessibility (modifier) only by admin
-		if (address(object2).call(abi.encodeWithSignature(functionSigCreatePermission,
-			permission1, true, true, true))) return "Creating a permission without the admin role should revert";
 
 		return SUCCESS;
 	}

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.25;
+
+import "commons-auth/Permissioned.sol";
+import "commons-auth/AbstractPermissioned.sol";
+
+contract PermissionedTest {
+	
+	string constant SUCCESS = "success";
+
+	/**
+	 * @dev Tests the functions of a Permissioned contract
+	 */
+	function testPermissions() external returns (string) {
+
+
+		return SUCCESS;
+	}
+
+}
+
+contract PermissionedObject is AbstractPermissioned {
+
+	constructor() public {
+		
+	}
+}

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -12,6 +12,10 @@ contract PermissionedTest {
 	 */
 	function testPermissions() external returns (string) {
 
+		PermissionedObject object = new PermissionedObject(msg.sender);
+		if (!object.hasPermission(object.ROLE_ID_PERMISSION_ADMIN(), address(this))) return "The test contract should be the permission admin first";
+		object.transferPermission(object.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
+		if (!object.hasPermission(object.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The msg.sender should be the permission admin after transfer";
 
 		return SUCCESS;
 	}
@@ -20,7 +24,9 @@ contract PermissionedTest {
 
 contract PermissionedObject is AbstractPermissioned {
 
-	constructor() public {
-		
+	address creator;
+
+	constructor(address _creator) public {
+		creator = _creator;
 	}
 }

--- a/contracts/src/commons-auth/test/PermissionedTest.sol
+++ b/contracts/src/commons-auth/test/PermissionedTest.sol
@@ -24,11 +24,11 @@ contract PermissionedTest {
 
 		// Make a permissioned object with no pre-determined admin
 		PermissionedObject object1 = new PermissionedObject(address(0));
-		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), address(this))) return "The test contract should be the admin for object1";
+		if (!object1.hasPermission(object1.ROLE_ID_OBJECT_ADMIN(), address(this))) return "The test contract should be the admin for object1";
 
 		// Make a permissioned object with pre-determined admin
 		PermissionedObject object2 = new PermissionedObject(msg.sender);
-		if (!object2.hasPermission(object2.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The test msg.sender should be the admin for object2";
+		if (!object2.hasPermission(object2.ROLE_ID_OBJECT_ADMIN(), msg.sender)) return "The test msg.sender should be the admin for object2";
 
 		// verify function signatures are all working before testing revert scenarios!
 		if (!address(object1).call(abi.encodeWithSignature(functionSigCreatePermission,
@@ -51,12 +51,12 @@ contract PermissionedTest {
 		object3.createPermission(permission1, true, true, true);
 		object3.createPermission(permission2, true, true, true);
 		object3.grantPermission(permission2, msg.sender);
-		object3.transferPermission(object3.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
+		object3.transferPermission(object3.ROLE_ID_OBJECT_ADMIN(), msg.sender);
 
     // Revert Scenarios:
 
     /* createPermission
-      1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+      1. Fails pre_requiresPermission(ROLE_ID_OBJECT_ADMIN)
       2. Permission already exists
     */
     if (address(object3).call(abi.encodeWithSignature(functionSigCreatePermission,
@@ -65,7 +65,7 @@ contract PermissionedTest {
 			permission1, true, false, false))) return "Creating a permission that already exists should revert";
 
     /* grantPermission
-      1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+      1. Fails pre_requiresPermission(ROLE_ID_OBJECT_ADMIN)
       2. Permission does not exist
       3. Overwritting an already-granted single-holder permission
     */
@@ -95,7 +95,7 @@ contract PermissionedTest {
 			permission1, address(this)))) return "Transfering a permission to an account already holding the permission should revert";
 
     /* revokePermission
-      1. Fails pre_requiresPermission(ROLE_ID_PERMISSION_ADMIN)
+      1. Fails pre_requiresPermission(ROLE_ID_OBJECT_ADMIN)
       2. Permission does not exist
       3. Permission is not revocable
       4. Permission is not held by specified account
@@ -107,7 +107,7 @@ contract PermissionedTest {
 		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
 			permission2, address(this)))) return "Revoking a non-revocable permission should revert";
 		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
-			object1.ROLE_ID_PERMISSION_ADMIN(), address(this)))) return "Revoking the admin permission from the only holder should revert";
+			object1.ROLE_ID_OBJECT_ADMIN(), address(this)))) return "Revoking the admin permission from the only holder should revert";
 		if (address(object1).call(abi.encodeWithSignature(functionSigRevokePermission,
 			permission1, msg.sender))) return "Revoking a permission from an account that doesn't hold the permission should revert";
 
@@ -122,9 +122,9 @@ contract PermissionedTest {
 		if (!object1.hasPermission(permission1, msg.sender)) return "msg.sender should have had permission1 on object1 transfered to them";
 		if (object1.hasPermission(permission1, address(this))) return "Test contract should have had permission1 on object1 transfered from them";
 
-		// Test transfer of permission admin role
-		object1.transferPermission(object1.ROLE_ID_PERMISSION_ADMIN(), msg.sender);
-		if (!object1.hasPermission(object1.ROLE_ID_PERMISSION_ADMIN(), msg.sender)) return "The msg.sender should be the admin after transfer from test contract";
+		// Test transfer of object admin role
+		object1.transferPermission(object1.ROLE_ID_OBJECT_ADMIN(), msg.sender);
+		if (!object1.hasPermission(object1.ROLE_ID_OBJECT_ADMIN(), msg.sender)) return "The msg.sender should be the admin after transfer from test contract";
 
 		return SUCCESS;
 	}
@@ -136,7 +136,7 @@ contract PermissionedObject is AbstractPermissioned {
 	address creator;
 
 	constructor(address _creator) AbstractPermissioned() public {
-		initializeAdministrator(_creator);
+		initializeObjectAdministrator(_creator);
 		creator = _creator;
 	}
 

--- a/contracts/src/test-commons-auth.yaml
+++ b/contracts/src/test-commons-auth.yaml
@@ -131,23 +131,23 @@ jobs:
 ##########
 # UserAccount Tests
 
-- name: UserAccountTest
-  deploy:
-    contract: UserAccountTest.bin
-    instance: UserAccountTest
-    libraries: ErrorsLib:$ErrorsLib, TypeUtilsLib:$TypeUtilsLib, MappingsLib:$MappingsLib
+# - name: UserAccountTest
+#   deploy:
+#     contract: UserAccountTest.bin
+#     instance: UserAccountTest
+#     libraries: ErrorsLib:$ErrorsLib, TypeUtilsLib:$TypeUtilsLib, MappingsLib:$MappingsLib
 
-- name: testCallForwarding
-  call:
-    destination: $UserAccountTest
-    bin: UserAccountTest
-    function: testCallForwarding
+# - name: testCallForwarding
+#   call:
+#     destination: $UserAccountTest
+#     bin: UserAccountTest
+#     function: testCallForwarding
 
-- name: assertCallForwarding
-  assert:
-    key: $testCallForwarding
-    relation: eq
-    val: success
+# - name: assertCallForwarding
+#   assert:
+#     key: $testCallForwarding
+#     relation: eq
+#     val: success
 
 
 ##########
@@ -157,7 +157,7 @@ jobs:
   deploy:
     contract: PermissionedTest.bin
     instance: PermissionedTest
-    libraries: ErrorsLib:$ErrorsLib, ArrayUtilsAPI:$ArrayUtilsAPI
+    libraries: ErrorsLib:$ErrorsLib, ArrayUtilsLib:$ArrayUtilsLib
 
 - name: testPermissions
   call:

--- a/contracts/src/test-commons-auth.yaml
+++ b/contracts/src/test-commons-auth.yaml
@@ -131,23 +131,23 @@ jobs:
 ##########
 # UserAccount Tests
 
-# - name: UserAccountTest
-#   deploy:
-#     contract: UserAccountTest.bin
-#     instance: UserAccountTest
-#     libraries: ErrorsLib:$ErrorsLib, TypeUtilsLib:$TypeUtilsLib, MappingsLib:$MappingsLib
+- name: UserAccountTest
+  deploy:
+    contract: UserAccountTest.bin
+    instance: UserAccountTest
+    libraries: ErrorsLib:$ErrorsLib, TypeUtilsLib:$TypeUtilsLib, MappingsLib:$MappingsLib
 
-# - name: testCallForwarding
-#   call:
-#     destination: $UserAccountTest
-#     bin: UserAccountTest
-#     function: testCallForwarding
+- name: testCallForwarding
+  call:
+    destination: $UserAccountTest
+    bin: UserAccountTest
+    function: testCallForwarding
 
-# - name: assertCallForwarding
-#   assert:
-#     key: $testCallForwarding
-#     relation: eq
-#     val: success
+- name: assertCallForwarding
+  assert:
+    key: $testCallForwarding
+    relation: eq
+    val: success
 
 
 ##########

--- a/contracts/src/test-commons-auth.yaml
+++ b/contracts/src/test-commons-auth.yaml
@@ -151,6 +151,28 @@ jobs:
 
 
 ##########
+# Permissioned Tests
+
+- name: PermissionedTest
+  deploy:
+    contract: PermissionedTest.bin
+    instance: PermissionedTest
+    libraries: ErrorsLib:$ErrorsLib, ArrayUtilsAPI:$ArrayUtilsAPI
+
+- name: testPermissions
+  call:
+    destination: $PermissionedTest
+    bin: PermissionedTest
+    function: testPermissions
+
+- name: assertPermissions
+  assert:
+    key: $testPermissions
+    relation: eq
+    val: success
+
+
+##########
 # ParticipantsManager Tests
 
 - name: ParticipantsManagerTest

--- a/contracts/upgrades/Archetype.yaml
+++ b/contracts/upgrades/Archetype.yaml
@@ -1,0 +1,100 @@
+jobs:
+
+#####
+# Retrieve DOUG
+#####
+- name: DOUG
+  query-name:
+      name: DOUG
+      field: data
+
+#####
+# Retrieve Library Addresses
+#####
+- name: ErrorsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ErrorsLib]
+
+- name: TypeUtilsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [TypeUtilsLib]
+
+- name: ArrayUtilsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ArrayUtilsLib]
+
+- name: MappingsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [MappingsLib]
+
+#####
+# Archetype Upgrade
+#####
+- name: ArchetypeRegistry
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ArchetypeRegistry]
+
+- name: ObjectClassArchetype
+  query-contract:
+    destination: $ArchetypeRegistry
+    bin: ArchetypeRegistry
+    function: OBJECT_CLASS_ARCHETYPE
+
+- name: ArchetypeImplementationCurrentLookup
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [$ObjectClassArchetype]
+
+- name: ArchetypeVersionBeforeUpgrade
+  query-contract:
+    destination: $ArchetypeImplementationCurrentLookup
+    bin: Archetype
+    function: getArtifactVersion
+
+- name: ArchetypeImplementationUpgrade
+  deploy:
+    contract: DefaultArchetype.bin
+    libraries: ErrorsLib:$ErrorsLib, TypeUtilsLib:$TypeUtilsLib, ArrayUtilsLib:$ArrayUtilsLib, MappingsLib:$MappingsLib
+
+- name: RegisterArchetypeObjectClass
+  call:
+    destination: $DOUG
+    bin: DOUG
+    function: register
+    data: [$ObjectClassArchetype, $ArchetypeImplementationUpgrade]
+
+- name: ArchetypeImplementationUpgradeLookup
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [$ObjectClassArchetype]
+
+- name: ArchetypeVersionAfterUpgrade
+  query-contract:
+    destination: $ArchetypeImplementationUpgradeLookup
+    bin: Archetype
+    function: getArtifactVersion
+
+- name: AssertArchetypeUpgradeRegistered
+  assert:
+    key: $ArchetypeImplementationUpgradeLookup
+    relation: eq
+    val: $ArchetypeImplementationUpgrade

--- a/contracts/upgrades/ArchetypeRegistry.yaml
+++ b/contracts/upgrades/ArchetypeRegistry.yaml
@@ -47,7 +47,6 @@ jobs:
   deploy:
     contract: DefaultArchetypeRegistry.bin
     libraries: ErrorsLib:$ErrorsLib, ArrayUtilsLib:$ArrayUtilsLib, MappingsLib:$MappingsLib
-    data: ["ArchetypeRegistry"]
 
 - name: ChangeUpgradeOwnership
   call:

--- a/contracts/upgrades/ArchetypeRegistry.yaml
+++ b/contracts/upgrades/ArchetypeRegistry.yaml
@@ -1,0 +1,84 @@
+jobs:
+
+#####
+# Retrieve DOUG
+#####
+- name: DOUG
+  query-name:
+      name: DOUG
+      field: data
+
+#####
+# Retrieve Library Addresses
+#####
+- name: ErrorsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ErrorsLib]
+
+- name: ArrayUtilsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ArrayUtilsLib]
+
+- name: MappingsLib
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [MappingsLib]
+
+#####
+# ArchetypeRegistry Upgrade
+#####
+
+- name: OldArchetypeRegistry
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ArchetypeRegistry]
+
+- name: NewArchetypeRegistry
+  deploy:
+    contract: DefaultArchetypeRegistry.bin
+    libraries: ErrorsLib:$ErrorsLib, ArrayUtilsLib:$ArrayUtilsLib, MappingsLib:$MappingsLib
+    data: ["ArchetypeRegistry"]
+
+- name: ChangeUpgradeOwnership
+  call:
+    destination: $NewArchetypeRegistry
+    bin: UpgradeOwned
+    function: transferUpgradeOwnership
+    data: [$DOUG]
+
+- name: DeployNewArchetypeRegistry
+  call:
+    destination: $DOUG
+    bin: DOUG
+    function: deploy
+    data: ["ArchetypeRegistry", $NewArchetypeRegistry]
+
+- name: AssertArchetypeRegistry
+  assert:
+    key: $DeployNewArchetypeRegistry
+    relation: eq
+    val: "true"
+
+# Retrieve the updated repository via DOUG
+- name: UpdatedArchetypeRegistry
+  query-contract:
+    destination: $DOUG
+    bin: DOUG
+    function: lookup
+    data: [ArchetypeRegistry]
+
+- name: AssertUpdatedArchetypeRegistry
+  assert:
+    key: $UpdatedArchetypeRegistry
+    relation: eq
+    val: $NewArchetypeRegistry


### PR DESCRIPTION
- Made Archetype and ActiveAgreement `Permissioned` contracts
- Updated `author` and `creator` of Archetype and ActiveAgreement, respectively, to be permissions
- Added `owner` permissions to Archetype and ActiveAgreement
- Added `owner` columns to archetypes and agreements vent tables
- API changes to handle all the above
- Set object admin for agreement after agreement creation in API