### PR TITLE
Restore original event definitions and versionize new ones

### DIFF
--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -15,7 +15,21 @@ import "agreements/Agreements.sol";
  */
 contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, AddressScopes, Signable, EventEmitter {
 
+	// original event definition
 	event LogAgreementCreation(
+		bytes32 indexed eventId,
+		address	agreementAddress,
+		address	archetypeAddress,
+		address	creator,
+		bool isPrivate,
+		uint8 legalState,
+		uint32 maxEventCount,
+		string privateParametersFileReference,
+		string eventLogFileReference
+	);
+
+	// v1.0.0 LogAgreementCreation event with added field 'owner' and modified parameters ordering
+	event LogAgreementCreation_v1_1_0(
 		bytes32 indexed eventId,
 		address	agreementAddress,
 		address	archetypeAddress,

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -28,7 +28,7 @@ contract ActiveAgreement is VersionedArtifact, Permissioned, DataStorage, Addres
 		string eventLogFileReference
 	);
 
-	// v1.0.0 LogAgreementCreation event with added field 'owner' and modified parameters ordering
+	// v1.1.0 LogAgreementCreation event with added field 'owner' and modified parameters ordering
 	event LogAgreementCreation_v1_1_0(
 		bytes32 indexed eventId,
 		address	agreementAddress,

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -24,7 +24,7 @@ contract Archetype is VersionedArtifact, Permissioned {
 		address executionProcessDefinition
 	);
 
-	// v1.0.0 LogArchetypeCreation event with added field 'owner'
+	// v1.1.0 LogArchetypeCreation event with added field 'owner'
 	event LogArchetypeCreation_v1_1_0(
 		bytes32 indexed eventId,
 		address archetypeAddress,

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -11,7 +11,21 @@ import "commons-auth/Permissioned.sol";
  */
 contract Archetype is VersionedArtifact, Permissioned {
 
+	// original event definition
 	event LogArchetypeCreation(
+		bytes32 indexed eventId,
+		address archetypeAddress,
+		uint price,
+		address author,
+		bool active,
+		bool isPrivate,
+		address successor,
+		address formationProcessDefinition,
+		address executionProcessDefinition
+	);
+
+	// v1.0.0 LogArchetypeCreation event with added field 'owner'
+	event LogArchetypeCreation_v1_1_0(
 		bytes32 indexed eventId,
 		address archetypeAddress,
 		uint price,

--- a/contracts/src/agreements/DefaultActiveAgreement.sol
+++ b/contracts/src/agreements/DefaultActiveAgreement.sol
@@ -90,7 +90,7 @@ contract DefaultActiveAgreement is AbstractVersionedArtifact(1,1,0), AbstractDel
     permissions[ROLE_ID_OWNER].transferable = true;
     permissions[ROLE_ID_OWNER].exists = true;
 
-		emit LogAgreementCreation(
+		emit LogAgreementCreation_v1_1_0(
 			EVENT_ID_AGREEMENTS,
 			address(this),
 			_archetype,

--- a/contracts/src/agreements/DefaultArchetype.sol
+++ b/contracts/src/agreements/DefaultArchetype.sol
@@ -95,7 +95,7 @@ contract DefaultArchetype is AbstractVersionedArtifact(1,1,0), AbstractDelegateT
     permissions[ROLE_ID_OWNER].exists = true;
 
 		// NOTE: some of the parameters for the event must be read from storage, otherwise "stack too deep" compilation errors occur
-		emit LogArchetypeCreation(
+		emit LogArchetypeCreation_v1_1_0(
 			EVENT_ID_ARCHETYPES,
 			address(this),
 			_price,


### PR DESCRIPTION
Original events LogArchetypeCreation and LogAgreementCreation were restored to allow event processing layers to process old events from chain. Latest event definitions were appended with v1_0_0.

Signed-off-by: Jan Hendrik Scheufen <j.h.scheufen@gmail.com>