### PR TITLE
Updated vent-helper height event listener

### DIFF
--- a/api/common/VentHelper.js
+++ b/api/common/VentHelper.js
@@ -40,15 +40,16 @@ class VentHelper {
         let resolved = false;
         log.debug(`Created result promise for target height [ ${target} ]`);
         const callback = (height) => {
-          // If the height has been reached, and resolve promise
+          // If the height has been reached, remove event listener and resolve promise
           if (height >= target) {
+            self.emitter.removeListener('height', callback);
             log.debug(`Resolving result promise for target height [ ${target} ]`);
             resolved = true;
             resolve(result);
           }
         };
         log.debug(`Current high_water in promise: ${self.high_water}`);
-        self.emitter.once('height', callback);
+        self.emitter.on('height', callback);
         setTimeout(() => {
           if (!resolved) {
             log.warn(`>>>>>>> WARNING <<<<<<< ${new Date()}: Target height [ ${target} ] notification not received after ${self.maxWaitTime}ms, resolving promise anyway`);


### PR DESCRIPTION
Listener was added with ".once" instead of ".on" which might result in skipped notifications. Changed it to ".on" and removed the listener once target height is reached.

Signed-off-by: Sam Sinha <ssinha484@gmail.com>