### PR TITLE
burrow 0.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG SOLC_VERSION=0.4.25
-ARG BURROW_VERSION=0.25.0
+ARG BURROW_VERSION=0.26.0
 # This container provides the test environment from which the various test scripts
 # can be run
 # For solc binary

--- a/test/chain/burrow.toml
+++ b/test/chain/burrow.toml
@@ -90,7 +90,7 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
   Moniker = "TestValidator0"
   TendermintRoot = ".burrow"
   AuthorizedPeers = ""
-  CreateEmptyBlocks = true
+  CreateEmptyBlocks = false
   CreateEmptyBlocksInterval = 0
   TimeoutFactor = 0.1
 
@@ -108,10 +108,12 @@ ValidatorAddress = "0201EF325305ABD75E1FB8A8F539730F71547484"
 [RPC]
   [RPC.Info]
     Enabled = true
-    ListenAddress = "tcp://0.0.0.0:26658"
+    ListenHost = "0.0.0.0"
+    ListenPort = "26658"
   [RPC.GRPC]
     Enabled = true
-    ListenAddress = "tcp://0.0.0.0:10997"
+    ListenHost = "0.0.0.0"
+    ListenPort = "10997"
   [RPC.Profiler]
     Enabled = false
   [RPC.Metrics]


### PR DESCRIPTION
Note that this release makes the tendermint option CreateEmptyBlocks
work, so that is off now.

Signed-off-by: Sean Young <sean.young@monax.io>