### PR TITLE
Updating docker-compose to use burrow 0.28.1 for vent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,12 @@ services:
     - burrow
     - start
   vent:
-    # Vent is using burrow 0.28.0 which contains the append-only event log feature
+    # Vent is using burrow 0.28.1 which contains the append-only event log feature
     build:
       context: .
       args:
         BURROW_REPO: hyperledger/burrow
-        BURROW_VERSION: "0.28.0"
+        BURROW_VERSION: "0.28.1"
     restart: always
     command:
     - burrow


### PR DESCRIPTION
This burrow version removes varchar(100) limits on _vent_log columns.

Signed-off-by: Sam Sinha <ssinha484@gmail.com>