### PR TITLE
On user-id migration the old userid:address mapping is now removed

### DIFF
--- a/contracts/src/commons-auth/DefaultEcosystem.sol
+++ b/contracts/src/commons-auth/DefaultEcosystem.sol
@@ -125,5 +125,12 @@ contract DefaultEcosystem is AbstractVersionedArtifact(1,0,1), AbstractDelegateT
             "DefaultEcosystem.migrateUserAccount",
             "User with same _migrateToId already exists in given ecosystem"
         );
+        error = userAccounts.remove(_migrateFromId);
+        ErrorsLib.revertIf(
+            error != BaseErrors.NO_ERROR(),
+            ErrorsLib.RUNTIME_ERROR(),
+            "DefaultEcosystem.migrateUserAccount",
+            "Failed to remove key _migrateFromId from userAccounts map"
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Sam Sinha <ssinha484@gmail.com>