### PR TITLE
Remove node engines from package json

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -50,10 +50,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "engines": {
-    "node": "^9.5.0",
-    "npm": "^5.6.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/agreements-network/blackstone.git"


### PR DESCRIPTION
appears to be pinning to version we used to use not protecting from any specific incompatibility. Given
it is a library I think it is better not to contrain at this level. Could be persuaded otherwise on this. But trying to get CI working with yarn which rejects based on this.

Signed-off-by: Silas Davis <silas@monax.io>