### PR TITLE
Remove empty-string check on intervalID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release History
 
+- Version [4.0.0](#v4.0.0)
 - Version [3.0.0](#v3.0.0)
 - Version [2.2.0](#v2.2.0)
 - Version [2.1.0](#v2.1.0)
@@ -19,6 +20,12 @@
 - Version [0.6.0](#v0.6.0)
 - Version [0.5.2](#v0.5.2)
 - Version [0.5.1](#v0.5.1)
+
+## <a name="v4.0.0">Release 4.0.0 - pending</a>
+
+### Fixed
+
+- Remove empty-string check on intervalID since intervalID is currently UUID bytes not string bytes.
 
 ## <a name="v3.0.0">Release 3.0.0</a>
 

--- a/src/agreements/Completables.sol
+++ b/src/agreements/Completables.sol
@@ -26,7 +26,7 @@ contract CompletableOptions {
 // book keeping (e.g. metadata). This is by design (the idea was 'events are primary state'/don't store history twice -
 // sorry if that was a bad decision) and assumes that we can provide a mechanism (via Burrow or Vent DB)
 // to play back the events to a migration contract
-contract Completables is CompletableOptions, AbstractVersionedArtifact(1,0,0), AbstractUpgradeable {
+contract Completables is CompletableOptions, AbstractVersionedArtifact(1,1,0), AbstractUpgradeable {
     using Strings for *;
 
     bytes32 constant EVENT_ID_AGREEMENT_COMPLETABLE = "AN://agreement-completable";
@@ -171,9 +171,6 @@ contract Completables is CompletableOptions, AbstractVersionedArtifact(1,0,0), A
         if (threshold > franchisees.length) {
             revert(Strings.concat("Cannot create a completable with ratification threshold (", threshold.toString(),
                 ") greater than number of franchisees (", franchisees.length.toString(), ")"));
-        }
-        if (intervalId[0] == 0) {
-            revert("Completable intervalId must be non-empty");
         }
         completables[intervalId].intervalId = intervalId;
         completables[intervalId].agreementAddress = agreementAddress;


### PR DESCRIPTION
Since we allow intervalID to be arbitrary (e.g. UUID) bytes.

Signed-off-by: Silas Davis <silas@monax.io>